### PR TITLE
algebra: Add sub-modular structure to `algebra`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/lib.rs"
 benchmarks = []
 stats = ["benchmarks"]
 test_helpers = ["ark-bn254"]
+poly = []
 
 [[test]]
 name = "integration"

--- a/benches/circuit_msm_throughput.rs
+++ b/benches/circuit_msm_throughput.rs
@@ -2,9 +2,7 @@
 
 use std::time::{Duration, Instant};
 
-use ark_mpc::{
-    algebra::authenticated_curve::AuthenticatedPointResult, test_helpers::execute_mock_mpc,
-};
+use ark_mpc::{algebra::AuthenticatedPointResult, test_helpers::execute_mock_mpc};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use itertools::Itertools;
 use tokio::runtime::Builder as RuntimeBuilder;

--- a/benches/gate_throughput.rs
+++ b/benches/gate_throughput.rs
@@ -1,8 +1,8 @@
 use std::{path::Path, sync::Mutex};
 
 use ark_mpc::{
-    algebra::scalar::Scalar, beaver::PartyIDBeaverSource, network::NoRecvNetwork,
-    test_helpers::TestCurve, MpcFabric, PARTY0,
+    algebra::Scalar, beaver::PartyIDBeaverSource, network::NoRecvNetwork, test_helpers::TestCurve,
+    MpcFabric, PARTY0,
 };
 use cpuprofiler::{Profiler as CpuProfiler, PROFILER};
 use criterion::{

--- a/benches/gate_throughput_traced.rs
+++ b/benches/gate_throughput_traced.rs
@@ -4,8 +4,8 @@
 use std::time::Instant;
 
 use ark_mpc::{
-    algebra::scalar::Scalar, beaver::PartyIDBeaverSource, network::NoRecvNetwork,
-    test_helpers::TestCurve, MpcFabric, PARTY0,
+    algebra::Scalar, beaver::PartyIDBeaverSource, network::NoRecvNetwork, test_helpers::TestCurve,
+    MpcFabric, PARTY0,
 };
 use clap::Parser;
 use cpuprofiler::PROFILER;

--- a/benches/growable_buffer.rs
+++ b/benches/growable_buffer.rs
@@ -1,4 +1,4 @@
-use ark_mpc::{algebra::scalar::Scalar, buffer::GrowableBuffer, test_helpers::TestCurve};
+use ark_mpc::{algebra::Scalar, buffer::GrowableBuffer, test_helpers::TestCurve};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
 // --------------

--- a/benches/native_msm.rs
+++ b/benches/native_msm.rs
@@ -1,7 +1,7 @@
 //! Defines a benchmark for native multiscalar-multiplication on `Scalar` and `CurvePoint` types
 
 use ark_mpc::{
-    algebra::{curve::CurvePoint, scalar::Scalar},
+    algebra::{CurvePoint, Scalar},
     random_point,
     test_helpers::TestCurve,
 };

--- a/integration/authenticated_curve.rs
+++ b/integration/authenticated_curve.rs
@@ -2,11 +2,8 @@
 
 use ark_mpc::{
     algebra::{
-        authenticated_curve::{
-            test_helpers::{modify_mac, modify_public_modifier, modify_share},
-            AuthenticatedPointResult,
-        },
-        scalar::Scalar,
+        curve_test_helpers::{modify_mac, modify_public_modifier, modify_share},
+        AuthenticatedPointResult, Scalar,
     },
     random_point, PARTY0, PARTY1,
 };

--- a/integration/authenticated_scalar.rs
+++ b/integration/authenticated_scalar.rs
@@ -2,10 +2,7 @@
 //! a malicious-secure primitive
 
 use ark_mpc::{
-    algebra::{
-        authenticated_scalar::{test_helpers::*, AuthenticatedScalarResult},
-        scalar::Scalar,
-    },
+    algebra::{scalar_test_helpers::*, AuthenticatedScalarResult, Scalar},
     ResultValue, PARTY0, PARTY1,
 };
 use itertools::Itertools;

--- a/integration/circuits.rs
+++ b/integration/circuits.rs
@@ -1,10 +1,7 @@
 //! Tests for more complicated operations (i.e. circuits)
 
 use ark_mpc::{
-    algebra::{
-        authenticated_curve::AuthenticatedPointResult,
-        authenticated_scalar::AuthenticatedScalarResult, scalar::Scalar,
-    },
+    algebra::{AuthenticatedPointResult, AuthenticatedScalarResult, Scalar},
     random_point, PARTY0, PARTY1,
 };
 use itertools::Itertools;

--- a/integration/fabric.rs
+++ b/integration/fabric.rs
@@ -1,6 +1,6 @@
 //! Defines tests for the fabric directly
 
-use ark_mpc::{algebra::scalar::Scalar, PARTY0, PARTY1};
+use ark_mpc::{algebra::Scalar, PARTY0, PARTY1};
 
 use crate::{
     helpers::{assert_scalars_eq, await_result, share_scalar},

--- a/integration/helpers.rs
+++ b/integration/helpers.rs
@@ -4,9 +4,8 @@ use std::fmt::Debug;
 
 use ark_mpc::{
     algebra::{
-        authenticated_curve::AuthenticatedPointResult,
-        authenticated_scalar::AuthenticatedScalarResult, mpc_curve::MpcPointResult,
-        mpc_scalar::MpcScalarResult, scalar::Scalar,
+        AuthenticatedPointResult, AuthenticatedScalarResult, MpcPointResult, MpcScalarResult,
+        Scalar,
     },
     beaver::SharedValueSource,
     network::{NetworkPayload, PartyId},

--- a/integration/main.rs
+++ b/integration/main.rs
@@ -2,7 +2,7 @@ use std::{borrow::Borrow, io::Write, net::SocketAddr, process::exit, thread, tim
 
 use ark_bn254::G1Projective as Bn254Projective;
 use ark_mpc::{
-    algebra::{curve::CurvePoint, scalar::Scalar},
+    algebra::{CurvePoint, Scalar},
     network::{NetworkOutbound, NetworkPayload, QuicTwoPartyNet},
     MpcFabric, PARTY0,
 };

--- a/integration/mpc_curve.rs
+++ b/integration/mpc_curve.rs
@@ -1,11 +1,7 @@
 //! Defines tests for the `MpcPointResult` type and arithmetic on this type
 
 use ark_mpc::{
-    algebra::{
-        curve::CurvePointResult,
-        mpc_curve::MpcPointResult,
-        scalar::{Scalar, ScalarResult},
-    },
+    algebra::{CurvePointResult, MpcPointResult, Scalar, ScalarResult},
     random_point, PARTY0, PARTY1,
 };
 use itertools::Itertools;

--- a/integration/mpc_scalar.rs
+++ b/integration/mpc_scalar.rs
@@ -1,9 +1,6 @@
 //! Defines unit tests for `MpcScalarResult` types
 use ark_mpc::{
-    algebra::{
-        mpc_scalar::MpcScalarResult,
-        scalar::{Scalar, ScalarResult},
-    },
+    algebra::{MpcScalarResult, Scalar, ScalarResult},
     PARTY0, PARTY1,
 };
 use itertools::Itertools;

--- a/src/algebra/curve/authenticated_curve.rs
+++ b/src/algebra/curve/authenticated_curve.rs
@@ -14,6 +14,8 @@ use futures::{Future, FutureExt};
 use itertools::{izip, Itertools};
 
 use crate::{
+    algebra::macros::*,
+    algebra::scalar::*,
     commitment::{HashCommitment, HashCommitmentResult},
     error::MpcError,
     fabric::{MpcFabric, ResultValue},
@@ -21,11 +23,8 @@ use crate::{
 };
 
 use super::{
-    authenticated_scalar::AuthenticatedScalarResult,
     curve::{BatchCurvePointResult, CurvePoint, CurvePointResult},
-    macros::{impl_borrow_variants, impl_commutative},
     mpc_curve::MpcPointResult,
-    scalar::{Scalar, ScalarResult},
 };
 
 /// The number of underlying results in an `AuthenticatedPointResult`

--- a/src/algebra/curve/curve.rs
+++ b/src/algebra/curve/curve.rs
@@ -24,20 +24,13 @@ use serde::{de::Error as DeError, Deserialize, Serialize};
 
 use crate::{
     algebra::{
-        authenticated_curve::AUTHENTICATED_POINT_RESULT_LEN,
-        authenticated_scalar::AUTHENTICATED_SCALAR_RESULT_LEN,
+        macros::*, n_bytes_field, scalar::*, AUTHENTICATED_POINT_RESULT_LEN,
+        AUTHENTICATED_SCALAR_RESULT_LEN,
     },
     fabric::{ResultHandle, ResultValue},
 };
 
-use super::{
-    authenticated_curve::AuthenticatedPointResult,
-    authenticated_scalar::AuthenticatedScalarResult,
-    macros::{impl_borrow_variants, impl_commutative},
-    mpc_curve::MpcPointResult,
-    mpc_scalar::MpcScalarResult,
-    scalar::{n_bytes_field, Scalar, ScalarResult},
-};
+use super::{authenticated_curve::AuthenticatedPointResult, mpc_curve::MpcPointResult};
 
 /// The number of points and scalars to pull from an iterated MSM when
 /// performing a multiscalar multiplication

--- a/src/algebra/curve/mod.rs
+++ b/src/algebra/curve/mod.rs
@@ -1,0 +1,13 @@
+//! Defines curve types for shared authenticated, shared unauthenticated, and plaintext curve points
+#![allow(clippy::module_inception)]
+
+mod authenticated_curve;
+mod curve;
+mod mpc_curve;
+
+pub use authenticated_curve::*;
+pub use curve::*;
+pub use mpc_curve::*;
+
+#[cfg(feature = "test_helpers")]
+pub use authenticated_curve::test_helpers as curve_test_helpers;

--- a/src/algebra/curve/mpc_curve.rs
+++ b/src/algebra/curve/mpc_curve.rs
@@ -6,14 +6,12 @@ use std::ops::{Add, Mul, Neg, Sub};
 use ark_ec::CurveGroup;
 use itertools::Itertools;
 
-use crate::{fabric::ResultValue, network::NetworkPayload, MpcFabric, ResultId, PARTY0};
-
-use super::{
-    curve::{BatchCurvePointResult, CurvePoint, CurvePointResult},
-    macros::{impl_borrow_variants, impl_commutative},
-    mpc_scalar::MpcScalarResult,
-    scalar::{Scalar, ScalarResult},
+use crate::{
+    algebra::macros::*, algebra::scalar::*, fabric::ResultValue, network::NetworkPayload,
+    MpcFabric, ResultId, PARTY0,
 };
+
+use super::curve::{BatchCurvePointResult, CurvePoint, CurvePointResult};
 
 /// Defines a secret shared type of a curve point
 #[derive(Clone, Debug)]

--- a/src/algebra/mod.rs
+++ b/src/algebra/mod.rs
@@ -1,9 +1,10 @@
 //! Defines algebraic MPC types and operations on them
 
-pub mod authenticated_curve;
-pub mod authenticated_scalar;
-pub mod curve;
-pub mod macros;
-pub mod mpc_curve;
-pub mod mpc_scalar;
-pub mod scalar;
+mod curve;
+mod macros;
+mod poly;
+mod scalar;
+
+pub use curve::*;
+pub use poly::*;
+pub use scalar::*;

--- a/src/algebra/poly/authenticated_poly.rs
+++ b/src/algebra/poly/authenticated_poly.rs
@@ -1,0 +1,24 @@
+//! An authenticated polynomial over a `CurveGroup`'s scalar field
+//!
+//! Modeled after the `ark_poly::DensePolynomial` type, but allocated in an MPC fabric
+
+use ark_ec::CurveGroup;
+
+use crate::algebra::AuthenticatedScalarResult;
+
+/// An authenticated polynomial; i.e. a polynomial in which the coefficients are secret
+/// shared between parties
+///
+/// This is modeled after the `ark_poly::DensePolynomial` [source](https://github.com/arkworks-rs/algebra/blob/master/poly/src/polynomial/univariate/dense.rs#L22)
+#[derive(Debug, Clone)]
+pub struct AuthenticatedDensePoly<C: CurveGroup> {
+    /// A vector of coefficients, the coefficient for `x^i` is stored at index `i`
+    pub coeffs: Vec<AuthenticatedScalarResult<C>>,
+}
+
+impl<C: CurveGroup> AuthenticatedDensePoly<C> {
+    /// Constructor
+    pub fn from_coeffs(coeffs: Vec<AuthenticatedScalarResult<C>>) -> Self {
+        Self { coeffs }
+    }
+}

--- a/src/algebra/poly/mod.rs
+++ b/src/algebra/poly/mod.rs
@@ -1,0 +1,7 @@
+//! Polynomial types over secret shared fields
+//!
+//! Modeled after the `ark_poly` implementation
+
+mod authenticated_poly;
+
+pub use authenticated_poly::*;

--- a/src/algebra/scalar/authenticated_scalar.rs
+++ b/src/algebra/scalar/authenticated_scalar.rs
@@ -13,6 +13,7 @@ use futures::{Future, FutureExt};
 use itertools::{izip, Itertools};
 
 use crate::{
+    algebra::{macros::*, AuthenticatedPointResult, CurvePoint, CurvePointResult},
     commitment::{PedersenCommitment, PedersenCommitmentResult},
     error::MpcError,
     fabric::{MpcFabric, ResultId, ResultValue},
@@ -20,9 +21,6 @@ use crate::{
 };
 
 use super::{
-    authenticated_curve::AuthenticatedPointResult,
-    curve::{CurvePoint, CurvePointResult},
-    macros::{impl_borrow_variants, impl_commutative},
     mpc_scalar::MpcScalarResult,
     scalar::{BatchScalarResult, Scalar, ScalarResult},
 };

--- a/src/algebra/scalar/mod.rs
+++ b/src/algebra/scalar/mod.rs
@@ -1,0 +1,13 @@
+//! Scalar type arithmetic with shared authenticated, shared non-authenticated, and plaintext types
+#![allow(clippy::module_inception)]
+
+mod authenticated_scalar;
+mod mpc_scalar;
+mod scalar;
+
+pub use authenticated_scalar::*;
+pub use mpc_scalar::*;
+pub use scalar::*;
+
+#[cfg(feature = "test_helpers")]
+pub use authenticated_scalar::test_helpers as scalar_test_helpers;

--- a/src/algebra/scalar/mpc_scalar.rs
+++ b/src/algebra/scalar/mpc_scalar.rs
@@ -7,18 +7,15 @@ use ark_ec::CurveGroup;
 use itertools::Itertools;
 
 use crate::{
-    algebra::scalar::BatchScalarResult,
+    algebra::macros::*,
+    algebra::BatchScalarResult,
+    algebra::{CurvePoint, CurvePointResult, MpcPointResult},
     fabric::{MpcFabric, ResultValue},
     network::NetworkPayload,
     PARTY0,
 };
 
-use super::{
-    curve::{CurvePoint, CurvePointResult},
-    macros::{impl_borrow_variants, impl_commutative},
-    mpc_curve::MpcPointResult,
-    scalar::{Scalar, ScalarResult},
-};
+use super::scalar::{Scalar, ScalarResult};
 
 /// Defines a secret shared type over the `Scalar` field
 #[derive(Clone, Debug)]

--- a/src/algebra/scalar/scalar.rs
+++ b/src/algebra/scalar/scalar.rs
@@ -18,9 +18,8 @@ use num_bigint::BigUint;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
+use crate::algebra::macros::*;
 use crate::fabric::{ResultHandle, ResultValue};
-
-use super::macros::{impl_borrow_variants, impl_commutative};
 
 // -----------
 // | Helpers |

--- a/src/beaver.rs
+++ b/src/beaver.rs
@@ -4,7 +4,7 @@
 use ark_ec::CurveGroup;
 use itertools::Itertools;
 
-use crate::algebra::scalar::Scalar;
+use crate::algebra::Scalar;
 
 /// SharedValueSource implements both the functionality for:
 ///     1. Single additively shared values [x] where party 1 holds

--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -6,10 +6,7 @@ use rand::thread_rng;
 use sha3::{Digest, Sha3_256};
 
 use crate::{
-    algebra::{
-        curve::{CurvePoint, CurvePointResult},
-        scalar::{Scalar, ScalarResult},
-    },
+    algebra::{CurvePoint, CurvePointResult, Scalar, ScalarResult},
     fabric::ResultValue,
 };
 

--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -35,12 +35,9 @@ use itertools::Itertools;
 
 use crate::{
     algebra::{
-        authenticated_curve::AuthenticatedPointResult,
-        authenticated_scalar::AuthenticatedScalarResult,
-        curve::{BatchCurvePointResult, CurvePoint, CurvePointResult},
-        mpc_curve::MpcPointResult,
-        mpc_scalar::MpcScalarResult,
-        scalar::{BatchScalarResult, Scalar, ScalarResult},
+        AuthenticatedPointResult, AuthenticatedScalarResult, BatchCurvePointResult,
+        BatchScalarResult, CurvePoint, CurvePointResult, MpcPointResult, MpcScalarResult, Scalar,
+        ScalarResult,
     },
     beaver::SharedValueSource,
     network::{MpcNetwork, NetworkOutbound, NetworkPayload, PartyId},

--- a/src/fabric/result.rs
+++ b/src/fabric/result.rs
@@ -14,7 +14,7 @@ use ark_ec::CurveGroup;
 use futures::Future;
 
 use crate::{
-    algebra::{curve::CurvePoint, scalar::Scalar},
+    algebra::{CurvePoint, Scalar},
     network::NetworkPayload,
     Shared,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 
 use std::sync::{Arc, RwLock};
 
-use algebra::{curve::CurvePoint, scalar::Scalar};
+use algebra::{CurvePoint, Scalar};
 use ark_ec::CurveGroup;
 
 use rand::thread_rng;

--- a/src/network.rs
+++ b/src/network.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    algebra::{curve::CurvePoint, scalar::Scalar},
+    algebra::{CurvePoint, Scalar},
     error::MpcNetworkError,
     fabric::ResultId,
 };


### PR DESCRIPTION
### Purpose
This PR refactors the `algebra` module to split into `scalar`, `curve`, and `polynomial` algebra implementation as separate sub-modules. This cleanup is done ahead of the main `AuthenticatedDensePoly` implementation.

### Testing
- All unit and integration tests pass