### PR TITLE
algebra: poly: poly, authenticated-poly: Implement polynomial division methods

### DIFF
--- a/src/algebra/poly/poly.rs
+++ b/src/algebra/poly/poly.rs
@@ -245,6 +245,7 @@ impl<C: CurveGroup> Mul<&DensePolynomialResult<C>> for &DensePolynomialResult<C>
 impl_borrow_variants!(DensePolynomialResult<C>, Mul, mul, *, DensePolynomialResult<C>, C: CurveGroup);
 
 // --- Scalar Multiplication --- //
+
 impl<C: CurveGroup> Mul<&Scalar<C>> for &DensePolynomialResult<C> {
     type Output = DensePolynomialResult<C>;
 


### PR DESCRIPTION
### Purpose
This PR implements polynomial division on both public and shared polynomials. In both cases, this is floor division. For shared polynomials, both parties can locally compute the division operation when the divisor is public -- this generates secret shares of the quotient polynomial as explained in the code.

### Testing
- All unit and integration tests pass
- Tested all new arithmetic operations