### PR TITLE
algebra: authenticated-scalar: Implement FFT and IFFT on shared values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/lib.rs"
 benchmarks = []
 stats = ["benchmarks"]
 test_helpers = ["ark-bn254"]
-poly = ["ark-poly"]
 
 [[test]]
 name = "integration"
@@ -77,7 +76,7 @@ tokio = { version = "1.12", features = ["macros", "rt-multi-thread"] }
 ark-bn254 = { version = "0.4", optional = true }
 ark-ec = { version = "0.4", features = ["parallel"] }
 ark-ff = "0.4"
-ark-poly = { version = "0.4", optional = true, features = ["std", "parallel"] }
+ark-poly = { version = "0.4", features = ["std", "parallel"] }
 ark-serialize = "0.4"
 ark-std = "0.4"
 digest = "0.10"

--- a/src/algebra/mod.rs
+++ b/src/algebra/mod.rs
@@ -4,9 +4,7 @@ mod curve;
 mod macros;
 mod scalar;
 
-#[cfg(feature = "poly")]
 mod poly;
-#[cfg(feature = "poly")]
 pub use poly::*;
 
 pub use curve::*;


### PR DESCRIPTION
### Purpose
This PR implements FFT and inverse FFT on shared values. The DFT is a linear transformation; so on shared values this amounts to:
- Performing an FFT locally on the shares of the authenticated value
- Performing an FFT locally on the macs of an authenticated value
- No-op on the public modifier: this value tracks addition and subtraction of public constants, a Fourier transform does no public additions.

### Testing
- Unit and integration tests pass
- Tested FFT and inverse FFT on shared values