### PR TITLE
fabric: executor: Remove recursion to avoid stack overflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build
-        run: cargo build --workspace --verbose
+        run: cargo build --workspace --all-features --verbose
       - name: Run tests
         run: cargo test --lib --all-features --verbose


### PR DESCRIPTION
### Purpose
Previously we recursively called `handle_new_result` from the executor method to avoid brokering recursive evaluation through the slower job queue. For very deep circuits, this can lead to excessive recursion and a stack overflow.

Here we refactor the recursive approach into an iterative one from a dispatch method.

### Testing
- Unit and integration tests pass
- Wrote a test that reliably caused stack overflow, verified that the fix passes the test