### PR TITLE
algebra: Define `IntoField` and implement for `Scalar`

### DIFF
--- a/src/algebra/scalar/mod.rs
+++ b/src/algebra/scalar/mod.rs
@@ -6,9 +6,45 @@ mod authenticated_scalar;
 mod mpc_scalar;
 mod scalar;
 
+use ark_ec::CurveGroup;
+use ark_ff::Field;
 pub use authenticated_scalar::*;
 pub use mpc_scalar::*;
 pub use scalar::*;
 
 #[cfg(feature = "test_helpers")]
 pub use authenticated_scalar::test_helpers as scalar_test_helpers;
+
+/// Convert to a field element
+///
+/// This trait is used downstream to accept `Field`s or `Scalar`s
+/// in an interface. The trait must be defined in this crate to avoid
+/// conflicting implementations checks by an upstream crate
+pub trait FieldWrapper<F: Field> {
+    /// Convert a reference to a field element
+    #[allow(clippy::wrong_self_convention)]
+    fn into_field(&self) -> F;
+
+    /// Convert from a field element
+    fn from_field(f: &F) -> Self;
+}
+
+impl<F: Field> FieldWrapper<F> for F {
+    fn into_field(&self) -> F {
+        *self
+    }
+
+    fn from_field(f: &F) -> Self {
+        *f
+    }
+}
+
+impl<C: CurveGroup> FieldWrapper<C::ScalarField> for Scalar<C> {
+    fn into_field(&self) -> C::ScalarField {
+        self.inner()
+    }
+
+    fn from_field(f: &C::ScalarField) -> Self {
+        Self::new(*f)
+    }
+}

--- a/src/algebra/scalar/scalar.rs
+++ b/src/algebra/scalar/scalar.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use ark_ec::CurveGroup;
-use ark_ff::{batch_inversion, FftField, Field, PrimeField};
+use ark_ff::{batch_inversion, FftField, Field, One, PrimeField, Zero};
 use ark_poly::EvaluationDomain;
 use ark_std::UniformRand;
 use itertools::Itertools;
@@ -125,6 +125,22 @@ impl<C: CurveGroup> Scalar<C> {
         let le_bytes = val.to_bytes_le();
         let inner = C::ScalarField::from_le_bytes_mod_order(&le_bytes);
         Scalar(inner)
+    }
+}
+
+impl<C: CurveGroup> Zero for Scalar<C> {
+    fn zero() -> Self {
+        Self::zero()
+    }
+
+    fn is_zero(&self) -> bool {
+        self.0.is_zero()
+    }
+}
+
+impl<C: CurveGroup> One for Scalar<C> {
+    fn one() -> Self {
+        Self::one()
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR makes two small changes that allows for downstream crates to accept `Scalar` or `F: Field` in an interface (i.e. one that requires basic arithmetic only):
1. Define and implement `IntoField` as a way to convert to a known `F: Field` for storage in downstream crates.
2. Implement `ark_ff::Zero` and `ark_ff::One` to give standardized access to the identities of a `Scalar`

### Testing
- All tests pass