### PR TITLE
commitment: Use hash commitments instead of Pedersen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,10 +80,10 @@ tokio = { version = "1.12", features = ["macros", "rt-multi-thread"] }
 # == Arithemtic + Crypto == #
 ark-bn254 = { version = "0.4", optional = true }
 ark-ec = { version = "0.4", features = ["parallel"] }
-ark-ff = "0.4"
+ark-ff = { version = "0.4", features = ["parallel"] }
 ark-poly = { version = "0.4", features = ["std", "parallel"] }
 ark-serialize = "0.4"
-ark-std = "0.4"
+ark-std = { version = "0.4", features = ["parallel"] }
 digest = "0.10"
 num-bigint = "0.4"
 rand = "0.8"

--- a/src/algebra/curve/authenticated_curve.rs
+++ b/src/algebra/curve/authenticated_curve.rs
@@ -176,7 +176,7 @@ impl<C: CurveGroup> AuthenticatedPointResult<C> {
         // Check that the MAC check value is the correct opening of the
         // given commitment
         let peer_comm = HashCommitment {
-            value: peer_mac_share,
+            values: vec![peer_mac_share],
             blinder: peer_blinder,
             commitment: peer_mac_commitment,
         };
@@ -226,7 +226,7 @@ impl<C: CurveGroup> AuthenticatedPointResult<C> {
 
         // Once the parties have exchanged their commitments, they can open the
         // underlying MAC check value as they are bound by the commitment
-        let peer_mac_check = self.fabric().exchange_value(my_comm.value.clone());
+        let peer_mac_check = self.fabric().exchange_value(my_comm.values[0].clone());
         let blinder_result: ScalarResult<C> = self.fabric().allocate_scalar(my_comm.blinder);
         let peer_blinder = self.fabric().exchange_value(blinder_result);
 
@@ -305,7 +305,7 @@ impl<C: CurveGroup> AuthenticatedPointResult<C> {
 
         // --- Check the MAC Checks --- //
 
-        let mut mac_check_gate_deps = my_comms.iter().map(|comm| comm.value.id).collect_vec();
+        let mut mac_check_gate_deps = my_comms.iter().map(|comm| comm.values[0].id).collect_vec();
         mac_check_gate_deps.push(peer_mac_checks.id);
         mac_check_gate_deps.push(peer_blinders.id);
         mac_check_gate_deps.push(peer_comms.id);

--- a/src/algebra/curve/curve.rs
+++ b/src/algebra/curve/curve.rs
@@ -24,7 +24,7 @@ use serde::{de::Error as DeError, Deserialize, Serialize};
 
 use crate::{
     algebra::{
-        macros::*, n_bytes_field, scalar::*, AUTHENTICATED_POINT_RESULT_LEN,
+        macros::*, n_bytes_field, scalar::*, ToBytes, AUTHENTICATED_POINT_RESULT_LEN,
         AUTHENTICATED_SCALAR_RESULT_LEN,
     },
     fabric::{ResultHandle, ResultValue},
@@ -173,6 +173,12 @@ where
     /// element
     fn hash_to_field(buf: &[u8]) -> C::BaseField {
         Self::BaseField::from_be_bytes_mod_order(buf)
+    }
+}
+
+impl<C: CurveGroup> ToBytes for CurvePoint<C> {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_bytes()
     }
 }
 

--- a/src/algebra/mod.rs
+++ b/src/algebra/mod.rs
@@ -9,3 +9,9 @@ pub use poly::*;
 
 pub use curve::*;
 pub use scalar::*;
+
+/// Abstracts the process of binary serialization, used for commitments
+pub(crate) trait ToBytes {
+    /// Serialize the value to bytes
+    fn to_bytes(&self) -> Vec<u8>;
+}

--- a/src/algebra/poly/poly.rs
+++ b/src/algebra/poly/poly.rs
@@ -110,6 +110,14 @@ impl<C: CurveGroup> DensePolynomialResult<C> {
 
 /// Modular inversion implementation
 impl<C: CurveGroup> DensePolynomialResult<C> {
+    /// Reverse the order of the coefficients in the polynomial
+    pub fn rev(&self) -> Self {
+        let mut coeffs = self.coeffs.clone();
+        coeffs.reverse();
+
+        Self::from_coeffs(coeffs)
+    }
+
     /// Compute the multiplicative inverse of the polynomial mod x^t
     ///
     /// Done using the extended Euclidean algorithm

--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -2,83 +2,34 @@
 //! before opening it
 
 use ark_ec::CurveGroup;
+use itertools::Itertools;
 use rand::thread_rng;
 use sha3::{Digest, Sha3_256};
 
 use crate::{
-    algebra::{CurvePoint, CurvePointResult, Scalar, ScalarResult},
+    algebra::{Scalar, ScalarResult, ToBytes},
     fabric::ResultValue,
+    ResultHandle,
 };
-
-/// A handle on the result of a Pedersen commitment, including the committed
-/// secret
-///
-/// Of the form `value * G + blinder * H`
-pub(crate) struct PedersenCommitment<C: CurveGroup> {
-    /// The committed value
-    pub(crate) value: Scalar<C>,
-    /// The commitment blinder
-    pub(crate) blinder: Scalar<C>,
-    /// The value of the commitment
-    pub(crate) commitment: CurvePoint<C>,
-}
-
-impl<C: CurveGroup> PedersenCommitment<C> {
-    /// Verify that the given commitment is valid
-    pub(crate) fn verify(&self) -> bool {
-        let generator = CurvePoint::generator();
-        let commitment = generator * self.value + generator * self.blinder;
-
-        commitment == self.commitment
-    }
-}
-
-/// A Pedersen commitment that has been allocated in an MPC computation graph
-pub(crate) struct PedersenCommitmentResult<C: CurveGroup> {
-    /// The committed value
-    pub(crate) value: ScalarResult<C>,
-    /// The commitment blinder
-    pub(crate) blinder: Scalar<C>,
-    /// The value of the commitment
-    pub(crate) commitment: CurvePointResult<C>,
-}
-
-impl<C: CurveGroup> PedersenCommitmentResult<C> {
-    /// Create a new Pedersen commitment to an underlying value
-    pub(crate) fn commit(value: ScalarResult<C>) -> PedersenCommitmentResult<C> {
-        // Concretely, we use the curve generator for both `G` and `H` as is done
-        // in dalek-cryptography: https://github.com/dalek-cryptography/bulletproofs/blob/main/src/generators.rs#L44-L53
-        let mut rng = thread_rng();
-        let blinder = Scalar::random(&mut rng);
-        let generator = CurvePoint::generator();
-        let commitment = generator * &value + generator * blinder;
-
-        PedersenCommitmentResult { value, blinder, commitment }
-    }
-}
 
 /// A handle on the result of a salted Sha256 hash commitment, including the
 /// committed secret
 ///
-/// Of the form `H(salt || value)`
-///
-/// We use hash commitments to commit to curve points before opening them. There
-/// is no straightforward way to adapt Pedersen commitments to curve points, and
-/// we do not need the homomorphic properties of a Pedersen commitment
-pub(crate) struct HashCommitment<C: CurveGroup> {
-    /// The committed value
-    pub(crate) value: CurvePoint<C>,
+/// Of the form `H(value[0] || value[1] || ... || value[n] || blinder)`
+pub(crate) struct HashCommitment<C: CurveGroup, T: From<ResultValue<C>>> {
+    /// The committed values
+    pub(crate) values: Vec<T>,
     /// The blinder used in the commitment
     pub(crate) blinder: Scalar<C>,
     /// The value of the commitment
     pub(crate) commitment: Scalar<C>,
 }
 
-impl<C: CurveGroup> HashCommitment<C> {
+impl<C: CurveGroup, T: From<ResultValue<C>> + ToBytes> HashCommitment<C, T> {
     /// Verify that the given commitment is valid
     pub(crate) fn verify(&self) -> bool {
         // Create the bytes buffer
-        let mut bytes = self.value.to_bytes();
+        let mut bytes = self.values.iter().flat_map(ToBytes::to_bytes).collect_vec();
         bytes.append(&mut self.blinder.to_bytes_be());
 
         // Hash the bytes, squeeze an output, verify that it is equal to the commitment
@@ -93,25 +44,35 @@ impl<C: CurveGroup> HashCommitment<C> {
 }
 
 /// A hash commitment that has been allocated in an MPC computation graph
-pub(crate) struct HashCommitmentResult<C: CurveGroup> {
-    /// The committed value
-    pub(crate) value: CurvePointResult<C>,
+pub(crate) struct HashCommitmentResult<C: CurveGroup, T: From<ResultValue<C>>> {
+    /// The committed values
+    pub(crate) values: Vec<ResultHandle<C, T>>,
     /// The blinder used in the commitment
     pub(crate) blinder: Scalar<C>,
     /// The value of the commitment
     pub(crate) commitment: ScalarResult<C>,
 }
 
-impl<C: CurveGroup> HashCommitmentResult<C> {
+impl<C: CurveGroup, T: From<ResultValue<C>> + ToBytes> HashCommitmentResult<C, T> {
     /// Create a new hash commitment to an underlying value
-    pub(crate) fn commit(value: CurvePointResult<C>) -> HashCommitmentResult<C> {
+    pub(crate) fn commit(value: ResultHandle<C, T>) -> HashCommitmentResult<C, T> {
+        Self::batch_commit(vec![value])
+    }
+
+    /// Create a new hash commitment to a batch of values
+    pub(crate) fn batch_commit(values: Vec<ResultHandle<C, T>>) -> HashCommitmentResult<C, T> {
+        assert!(!values.is_empty(), "Cannot commit to an empty set of values");
+        let fabric = &values[0].fabric;
+
         let mut rng = thread_rng();
         let blinder = Scalar::random(&mut rng);
-        let comm = value.fabric.new_gate_op(vec![value.id], move |mut args| {
-            let value: CurvePoint<C> = args.remove(0).into();
+        let ids = values.iter().map(|v| v.id()).collect_vec();
+
+        let comm = fabric.new_gate_op(ids, move |args| {
+            let values = args.into_iter().map(Into::<T>::into);
+            let mut bytes = values.flat_map(|v| v.to_bytes()).collect_vec();
 
             // Create the bytes buffer
-            let mut bytes = value.to_bytes();
             bytes.append(&mut blinder.to_bytes_be());
 
             // Hash the bytes, squeeze an output, verify that it is equal to the commitment
@@ -124,6 +85,136 @@ impl<C: CurveGroup> HashCommitmentResult<C> {
             ResultValue::Scalar(out)
         });
 
-        HashCommitmentResult { value, blinder, commitment: comm }
+        HashCommitmentResult { values, blinder, commitment: comm }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use futures::future;
+    use itertools::Itertools;
+    use rand::thread_rng;
+
+    use crate::{
+        algebra::{CurvePoint, Scalar, ToBytes},
+        commitment::{HashCommitment, HashCommitmentResult},
+        test_helpers::{execute_mock_mpc, TestCurve},
+        ResultValue,
+    };
+
+    /// Verify a commitment to a value
+    async fn verify_comm<T: From<ResultValue<TestCurve>> + Unpin + ToBytes>(
+        comm: HashCommitmentResult<TestCurve, T>,
+    ) -> bool {
+        let comm_res = HashCommitment {
+            blinder: comm.blinder,
+            values: future::join_all(comm.values).await,
+            commitment: comm.commitment.await,
+        };
+
+        comm_res.verify()
+    }
+
+    /// Tests committing and verifying a scalar
+    #[tokio::test]
+    async fn test_scalar_commit() {
+        let mut rng = thread_rng();
+        let value = Scalar::<TestCurve>::random(&mut rng);
+
+        let (res, _) = execute_mock_mpc(|fabric| async move {
+            let allocated_value = fabric.allocate_scalar(value);
+
+            let comm = HashCommitmentResult::commit(allocated_value);
+            verify_comm(comm).await
+        })
+        .await;
+
+        assert!(res)
+    }
+
+    /// Tests committing and verifying a scalar batch commitment
+    #[tokio::test]
+    async fn test_scalar_batch_commit() {
+        const N: usize = 100;
+        let mut rng = thread_rng();
+        let values = (0..N).map(|_| Scalar::<TestCurve>::random(&mut rng)).collect_vec();
+
+        let (res, _) = execute_mock_mpc(|fabric| {
+            let values = values.clone();
+            async move {
+                let allocated_values = fabric.allocate_scalars(values.clone());
+
+                let comm = HashCommitmentResult::batch_commit(allocated_values);
+                verify_comm(comm).await
+            }
+        })
+        .await;
+
+        assert!(res)
+    }
+
+    /// Tests committing and verifying a curve point
+    #[tokio::test]
+    async fn test_point_commit() {
+        let mut rng = thread_rng();
+        let value = CurvePoint::<TestCurve>::generator() * Scalar::<TestCurve>::random(&mut rng);
+
+        let (res, _) = execute_mock_mpc(|fabric| async move {
+            let allocated_value = fabric.allocate_point(value);
+
+            let comm = HashCommitmentResult::commit(allocated_value);
+            verify_comm(comm).await
+        })
+        .await;
+
+        assert!(res)
+    }
+
+    /// Tests committing to a batch of curve points
+    #[tokio::test]
+    async fn test_point_batch_commit() {
+        const N: usize = 100;
+        let mut rng = thread_rng();
+        let values = (0..N)
+            .map(|_| CurvePoint::<TestCurve>::generator() * Scalar::<TestCurve>::random(&mut rng))
+            .collect_vec();
+
+        let (res, _) = execute_mock_mpc(|fabric| {
+            let values = values.clone();
+            async move {
+                let allocated_values = fabric.allocate_points(values.clone());
+
+                let comm = HashCommitmentResult::batch_commit(allocated_values);
+                verify_comm(comm).await
+            }
+        })
+        .await;
+
+        assert!(res)
+    }
+
+    /// Tests an invalid commitment
+    #[tokio::test]
+    async fn test_invalid_commit() {
+        let mut rng = thread_rng();
+        let value = Scalar::<TestCurve>::random(&mut rng);
+
+        let (res, _) = execute_mock_mpc(|fabric| async move {
+            let allocated_value = fabric.allocate_scalar(value);
+
+            let comm = HashCommitmentResult::commit(allocated_value);
+            let mut comm_res = HashCommitment {
+                blinder: comm.blinder,
+                values: future::join_all(comm.values).await,
+                commitment: comm.commitment.await,
+            };
+
+            // Modify the commitment
+            comm_res.commitment += Scalar::one();
+            !comm_res.verify()
+        })
+        .await;
+
+        assert!(res)
     }
 }

--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -270,7 +270,7 @@ impl<C: CurveGroup> FabricInner<C> {
 
     /// Increment the operation counter and return the existing value
     fn new_op_id(&self) -> OperationId {
-        self.next_op_id.fetch_add(1, Ordering::Relaxed)
+        self.next_op_id.fetch_add(1, Ordering::Acquire)
     }
 
     /// Get the hardcoded zero value in the fabric
@@ -446,7 +446,7 @@ impl<C: CurveGroup> MpcFabric<C> {
 
     /// Get the total number of ops that have been allocated in the fabric
     pub fn num_gates(&self) -> usize {
-        self.inner.next_op_id.load(Ordering::Relaxed)
+        self.inner.next_op_id.load(Ordering::Acquire)
     }
 
     /// Shutdown the fabric and the threads it has spawned

--- a/src/fabric/result.rs
+++ b/src/fabric/result.rs
@@ -235,7 +235,7 @@ impl<C: CurveGroup> Debug for ResultWaiter<C> {
     }
 }
 
-impl<C: CurveGroup, T: From<ResultValue<C>> + Unpin + Debug> Future for ResultHandle<C, T> {
+impl<C: CurveGroup, T: From<ResultValue<C>> + Unpin> Future for ResultHandle<C, T> {
     type Output = T;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {


### PR DESCRIPTION
### Purpose
This PR changes the commitment scheme underlying `Scalar` types to use a hash commitment rather than Pedersen. This is more efficient to compute and allows for simpler batch commit semantics. 

### Testing
- Unit and integration tests pass