### PR TITLE
fabric: executor: Add fine-grained size hints

### DIFF
--- a/benches/gate_throughput.rs
+++ b/benches/gate_throughput.rs
@@ -2,7 +2,7 @@ use std::{path::Path, sync::Mutex};
 
 use ark_mpc::{
     algebra::Scalar, beaver::PartyIDBeaverSource, network::NoRecvNetwork, test_helpers::TestCurve,
-    MpcFabric, PARTY0,
+    ExecutorSizeHints, MpcFabric, PARTY0,
 };
 use cpuprofiler::{Profiler as CpuProfiler, PROFILER};
 use criterion::{
@@ -43,7 +43,9 @@ pub fn config() -> Criterion {
 pub fn mock_fabric(size_hint: usize) -> MpcFabric<TestCurve> {
     let network = NoRecvNetwork::default();
     let beaver_source = PartyIDBeaverSource::new(PARTY0);
-    MpcFabric::new_with_size_hint(size_hint, network, beaver_source)
+    let size = ExecutorSizeHints { num_ops: size_hint, num_results: size_hint * 10 };
+
+    MpcFabric::new_with_size_hint(size, network, beaver_source)
 }
 
 // --------------

--- a/benches/gate_throughput_traced.rs
+++ b/benches/gate_throughput_traced.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use ark_mpc::{
     algebra::Scalar, beaver::PartyIDBeaverSource, network::NoRecvNetwork, test_helpers::TestCurve,
-    MpcFabric, PARTY0,
+    ExecutorSizeHints, MpcFabric, PARTY0,
 };
 use clap::Parser;
 use cpuprofiler::PROFILER;
@@ -23,7 +23,9 @@ const NUM_GATES: usize = 10_000_000;
 pub fn mock_fabric(size_hint: usize) -> MpcFabric<TestCurve> {
     let network = NoRecvNetwork::default();
     let beaver_source = PartyIDBeaverSource::new(PARTY0);
-    MpcFabric::new_with_size_hint(size_hint, network, beaver_source)
+    let size = ExecutorSizeHints { num_ops: size_hint, num_results: size_hint * 10 };
+
+    MpcFabric::new_with_size_hint(size, network, beaver_source)
 }
 
 pub fn start_cpu_profiler(profiled: bool) {

--- a/integration/main.rs
+++ b/integration/main.rs
@@ -131,8 +131,7 @@ fn main() {
         }
 
         let beaver_source = PartyIDBeaverSource::new(args.party);
-        let fabric =
-            MpcFabric::new_with_size_hint(10_000_000 /* size_hint */, net, beaver_source);
+        let fabric = MpcFabric::new(net, beaver_source);
 
         // ----------------
         // | Test Harness |

--- a/src/fabric/executor/mod.rs
+++ b/src/fabric/executor/mod.rs
@@ -18,6 +18,11 @@ pub mod single_threaded;
 #[cfg(feature = "benchmarks")]
 pub use buffer::*;
 
+/// The default number of operations to pre-allocate
+const DEFAULT_N_OPS: usize = 1000;
+/// The default number of results to pre-allocate
+const DEFAULT_N_RESULTS: usize = 10_000;
+
 /// The job queue that the executor may receive messages on
 #[allow(type_alias_bounds)]
 pub type ExecutorJobQueue<C: CurveGroup> = Arc<SegQueue<ExecutorMessage<C>>>;
@@ -47,4 +52,19 @@ pub enum ExecutorMessage<C: CurveGroup> {
     NewWaiter(ResultWaiter<C>),
     /// Indicates that the executor should shut down
     Shutdown,
+}
+
+/// Size hints given to an executor to pre-allocate buffer space
+#[derive(Debug, Clone, Copy)]
+pub struct ExecutorSizeHints {
+    /// The number of operations that will be executed
+    pub n_ops: usize,
+    /// The number of results that will be produced
+    pub n_results: usize,
+}
+
+impl Default for ExecutorSizeHints {
+    fn default() -> Self {
+        Self { n_ops: DEFAULT_N_OPS, n_results: DEFAULT_N_RESULTS }
+    }
 }

--- a/src/fabric/executor/multi_threaded/executor.rs
+++ b/src/fabric/executor/multi_threaded/executor.rs
@@ -20,7 +20,7 @@ use tracing::log;
 
 use crate::{
     fabric::{
-        executor::{buffer::GrowableBuffer, ExecutorJobQueue, ExecutorMessage},
+        executor::{buffer::GrowableBuffer, ExecutorJobQueue, ExecutorMessage, ExecutorSizeHints},
         result::{ResultWaiter, ERR_RESULT_BUFFER_POISONED},
         OpResult, Operation, OperationId, OperationType,
     },
@@ -60,17 +60,17 @@ pub struct ParallelExecutor<C: CurveGroup> {
 impl<C: CurveGroup> ParallelExecutor<C> {
     /// Constructor
     pub fn new(
-        circuit_size_hint: usize,
+        size_hints: ExecutorSizeHints,
         job_queue: Arc<SegQueue<ExecutorMessage<C>>>,
         network_outbound: KanalSender<NetworkOutbound<C>>,
     ) -> Self {
         let pool = ThreadPoolBuilder::new().build().expect("error building thread pool");
         Self {
             job_queue,
-            operations: GrowableBuffer::new(circuit_size_hint),
-            dependencies: GrowableBuffer::new(circuit_size_hint),
-            results: ParallelResultBuffer::new(circuit_size_hint),
-            ready_mask: ResultMask::new(circuit_size_hint),
+            operations: GrowableBuffer::new(size_hints.n_ops),
+            dependencies: GrowableBuffer::new(size_hints.n_ops),
+            results: ParallelResultBuffer::new(size_hints.n_results),
+            ready_mask: ResultMask::new(size_hints.n_results),
             waiters: HashMap::new(),
             pool,
             network_outbound,


### PR DESCRIPTION
### Purpose
This PR breaks out the size hint into two fields `n_ops` and `n_results`. Seeing as operations and results are no longer one-to-one, the new `ExecutorSizeHints` struct gives consumers a few knobs to fine tune for pre-allocation. I also added interfaces for passing size hints to mock MPCs for benchmarks, tests, etc.

I fine tuned benchmarks in `mpc-jellyfish` with this struct and saw a 30% speedup.

### Testing
- Unit and integration tests pass