### PR TITLE
algebra: authenticated-scalar: Optimize arithmetic level gate use

### DIFF
--- a/benches/gate_throughput.rs
+++ b/benches/gate_throughput.rs
@@ -43,7 +43,7 @@ pub fn config() -> Criterion {
 pub fn mock_fabric(size_hint: usize) -> MpcFabric<TestCurve> {
     let network = NoRecvNetwork::default();
     let beaver_source = PartyIDBeaverSource::new(PARTY0);
-    let size = ExecutorSizeHints { num_ops: size_hint, num_results: size_hint * 10 };
+    let size = ExecutorSizeHints { n_ops: size_hint, n_results: size_hint * 10 };
 
     MpcFabric::new_with_size_hint(size, network, beaver_source)
 }

--- a/benches/gate_throughput_traced.rs
+++ b/benches/gate_throughput_traced.rs
@@ -23,7 +23,7 @@ const NUM_GATES: usize = 10_000_000;
 pub fn mock_fabric(size_hint: usize) -> MpcFabric<TestCurve> {
     let network = NoRecvNetwork::default();
     let beaver_source = PartyIDBeaverSource::new(PARTY0);
-    let size = ExecutorSizeHints { num_ops: size_hint, num_results: size_hint * 10 };
+    let size = ExecutorSizeHints { n_ops: size_hint, n_results: size_hint * 10 };
 
     MpcFabric::new_with_size_hint(size, network, beaver_source)
 }

--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -973,11 +973,12 @@ impl<C: CurveGroup> MpcFabric<C> {
         let b_val = self.allocate_scalar(b);
         let c_val = self.allocate_scalar(c);
 
-        (
-            AuthenticatedScalarResult::new_shared(a_val),
-            AuthenticatedScalarResult::new_shared(b_val),
-            AuthenticatedScalarResult::new_shared(c_val),
-        )
+        let mut abc = AuthenticatedScalarResult::new_shared_batch(&[a_val, b_val, c_val]);
+        let c_val = abc.pop().unwrap();
+        let b_val = abc.pop().unwrap();
+        let a_val = abc.pop().unwrap();
+
+        (a_val, b_val, c_val)
     }
 
     /// Sample the next batch of beaver triples as `AuthenticatedScalar`s
@@ -1014,7 +1015,7 @@ impl<C: CurveGroup> MpcFabric<C> {
             .next_shared_value_batch(n);
 
         // Wrap the values in a result handle
-        values_raw.into_iter().map(|value| self.allocate_scalar(value)).collect_vec()
+        self.allocate_scalars(values_raw)
     }
 
     /// Sample a batch of random shared values from the beaver source and

--- a/src/gadgets.rs
+++ b/src/gadgets.rs
@@ -6,7 +6,142 @@ use std::iter;
 use ark_ec::CurveGroup;
 use itertools::Itertools;
 
-use crate::{algebra::AuthenticatedScalarResult, MpcFabric};
+use crate::{
+    algebra::{AuthenticatedScalarResult, Scalar, ScalarResult, AUTHENTICATED_SCALAR_RESULT_LEN},
+    MpcFabric, ResultValue, PARTY0,
+};
+
+/// Single bit xor, assumes that `a` and `b` are scalars representing bits
+///
+/// xor(a, b) = a + b - 2ab
+pub fn bit_xor<C: CurveGroup>(
+    a: &AuthenticatedScalarResult<C>,
+    b: &AuthenticatedScalarResult<C>,
+) -> AuthenticatedScalarResult<C> {
+    let a_times_b = a * b;
+    let fabric = a.fabric();
+    let ids = vec![
+        a.share.id(),
+        a.mac.id(),
+        a.public_modifier.id(),
+        b.share.id(),
+        b.mac.id(),
+        b.public_modifier.id(),
+        a_times_b.share.id(),
+        a_times_b.mac.id(),
+        a_times_b.public_modifier.id(),
+    ];
+
+    let mut results =
+        fabric.new_batch_gate_op(ids, AUTHENTICATED_SCALAR_RESULT_LEN, move |mut args| {
+            // Destructure the gate args
+            let a_share: Scalar<C> = args.next().unwrap().into();
+            let a_mac: Scalar<C> = args.next().unwrap().into();
+            let a_public_modifier: Scalar<C> = args.next().unwrap().into();
+
+            let b_share: Scalar<C> = args.next().unwrap().into();
+            let b_mac: Scalar<C> = args.next().unwrap().into();
+            let b_public_modifier: Scalar<C> = args.next().unwrap().into();
+
+            let a_times_b_share: Scalar<C> = args.next().unwrap().into();
+            let a_times_b_mac: Scalar<C> = args.next().unwrap().into();
+            let a_times_b_public_modifier: Scalar<C> = args.next().unwrap().into();
+
+            // Compute the xor identity
+            let two = Scalar::from(2u64);
+            let new_share = a_share + b_share - two * a_times_b_share;
+            let new_mac = a_mac + b_mac - two * a_times_b_mac;
+            let new_public_modifier =
+                a_public_modifier + b_public_modifier - two * a_times_b_public_modifier;
+
+            vec![
+                ResultValue::Scalar(new_share),
+                ResultValue::Scalar(new_mac),
+                ResultValue::Scalar(new_public_modifier),
+            ]
+        });
+
+    let public_modifier = results.pop().unwrap();
+    let mac = results.pop().unwrap().into();
+    let share = results.pop().unwrap().into();
+
+    AuthenticatedScalarResult { share, mac, public_modifier }
+}
+
+/// XOR a batch of bits
+pub fn bit_xor_batch<C: CurveGroup>(
+    a: &[AuthenticatedScalarResult<C>],
+    b: &[AuthenticatedScalarResult<C>],
+) -> Vec<AuthenticatedScalarResult<C>> {
+    assert_eq!(a.len(), b.len(), "bit_xor takes bit representations of equal length");
+
+    let a_plus_b = AuthenticatedScalarResult::batch_add(a, b);
+    let a_times_b = AuthenticatedScalarResult::batch_mul(a, b);
+
+    let twos = vec![Scalar::from(2u64); a.len()];
+    let twos_times_a_times_b = AuthenticatedScalarResult::batch_mul_constant(&a_times_b, &twos);
+
+    AuthenticatedScalarResult::batch_sub(&a_plus_b, &twos_times_a_times_b)
+}
+
+/// Single bit xor where one of the bits is public
+///
+/// xor(a, b) = a + b - 2ab
+pub fn bit_xor_public<C: CurveGroup>(
+    a: &ScalarResult<C>,
+    b: &AuthenticatedScalarResult<C>,
+) -> AuthenticatedScalarResult<C> {
+    let fabric = a.fabric();
+    let party0 = fabric.party_id() == PARTY0;
+    let ids = vec![a.id(), b.share.id(), b.mac.id(), b.public_modifier.id()];
+
+    let mut results =
+        fabric.new_batch_gate_op(ids, AUTHENTICATED_SCALAR_RESULT_LEN, move |mut args| {
+            // Public value
+            let a = args.next().unwrap().into();
+
+            // Shared value
+            let b_share: Scalar<C> = args.next().unwrap().into();
+            let b_mac: Scalar<C> = args.next().unwrap().into();
+            let b_public_modifier: Scalar<C> = args.next().unwrap().into();
+
+            // Compute the xor identity
+            let two = Scalar::from(2u64);
+            let additive_share = if party0 { a } else { Scalar::zero() };
+            let share = additive_share + b_share - two * a * b_share;
+
+            let mac = b_mac - two * a * b_mac;
+            let modifier = b_public_modifier - a - two * a * b_public_modifier;
+
+            vec![
+                ResultValue::Scalar(share),
+                ResultValue::Scalar(mac),
+                ResultValue::Scalar(modifier),
+            ]
+        });
+
+    let public_modifier = results.pop().unwrap();
+    let mac = results.pop().unwrap().into();
+    let share = results.pop().unwrap().into();
+
+    AuthenticatedScalarResult { share, mac, public_modifier }
+}
+
+/// XOR a batch of bits where one of the bit vectors is public
+pub fn bit_xor_public_batch<C: CurveGroup>(
+    a: &[ScalarResult<C>],
+    b: &[AuthenticatedScalarResult<C>],
+) -> Vec<AuthenticatedScalarResult<C>> {
+    assert_eq!(a.len(), b.len(), "bit_xor takes bit representations of equal length");
+
+    let a_plus_b = AuthenticatedScalarResult::batch_add_public(b, a);
+    let a_times_b = AuthenticatedScalarResult::batch_mul_public(b, a);
+
+    let twos = vec![Scalar::from(2u64); a.len()];
+    let twos_times_a_times_b = AuthenticatedScalarResult::batch_mul_constant(&a_times_b, &twos);
+
+    AuthenticatedScalarResult::batch_sub(&a_plus_b, &twos_times_a_times_b)
+}
 
 /// A prefix product gadget, computes the prefix products of a vector of values,
 /// where for `n` values, the `i`th prefix product is defined as:
@@ -66,11 +201,11 @@ pub fn prefix_product<C: CurveGroup>(
 mod test {
     use futures::future;
     use itertools::Itertools;
-    use rand::thread_rng;
+    use rand::{thread_rng, Rng};
 
     use crate::{
         algebra::{AuthenticatedScalarResult, Scalar},
-        gadgets::prefix_product,
+        gadgets::{bit_xor, bit_xor_batch, bit_xor_public, bit_xor_public_batch, prefix_product},
         test_helpers::execute_mock_mpc,
         PARTY0,
     };
@@ -103,5 +238,123 @@ mod test {
 
         let res = res.into_iter().collect::<Result<Vec<_>, _>>().unwrap();
         assert_eq!(res, expected_res)
+    }
+
+    /// Test the xor gadget
+    #[tokio::test]
+    async fn test_xor() {
+        let (res, _) = execute_mock_mpc(|fabric| {
+            async move {
+                let zero = fabric.zero_authenticated();
+                let one = fabric.one_authenticated();
+
+                // 0 ^ 0 = 0
+                let res = bit_xor(&zero, &zero).open_authenticated().await.unwrap();
+                let mut success = res == Scalar::zero();
+
+                // 0 ^ 1 = 1
+                let res = bit_xor(&zero, &one).open_authenticated().await.unwrap();
+                success = success && res == Scalar::one();
+
+                // 1 ^ 0 = 1
+                let res = bit_xor(&one, &zero).open_authenticated().await.unwrap();
+                success = success && res == Scalar::one();
+
+                // 1 ^ 1 = 0
+                let res = bit_xor(&one, &one).open_authenticated().await.unwrap();
+                success && res == Scalar::zero()
+            }
+        })
+        .await;
+
+        assert!(res)
+    }
+
+    /// Test the batch xor gadget
+    #[tokio::test]
+    async fn test_xor_batch() {
+        const N: usize = 10;
+        let mut rng = thread_rng();
+        let a = (0..N).map(|_| Scalar::from(rng.gen_bool(0.5))).collect_vec();
+        let b = (0..N).map(|_| Scalar::from(rng.gen_bool(0.5))).collect_vec();
+
+        let expected_res =
+            a.iter().zip(b.iter()).map(|(a, b)| a + b - Scalar::from(2u64) * a * b).collect_vec();
+
+        let (res, _) = execute_mock_mpc(|fabric| {
+            let a = a.clone();
+            let b = b.clone();
+            async move {
+                let a = fabric.batch_share_scalar(a, PARTY0 /* sender */);
+                let b = fabric.batch_share_scalar(b, PARTY0 /* sender */);
+                let res = bit_xor_batch(&a, &b);
+                let res_open = AuthenticatedScalarResult::open_authenticated_batch(&res);
+
+                future::join_all(res_open).await.into_iter().collect::<Result<Vec<_>, _>>()
+            }
+        })
+        .await;
+
+        assert_eq!(res.unwrap(), expected_res)
+    }
+
+    /// Test the xor public gadget
+    #[tokio::test]
+    async fn test_xor_public() {
+        let (res, _) = execute_mock_mpc(|fabric| {
+            async move {
+                let zero = fabric.zero();
+                let one = fabric.one();
+                let zero_auth = fabric.zero_authenticated();
+                let one_auth = fabric.one_authenticated();
+
+                // 0 ^ 0 = 0
+                let res = bit_xor_public(&zero, &zero_auth).open_authenticated().await.unwrap();
+                let mut success = res == Scalar::zero();
+
+                // 0 ^ 1 = 1
+                let res = bit_xor_public(&zero, &one_auth).open_authenticated().await.unwrap();
+                success = success && res == Scalar::one();
+
+                // 1 ^ 0 = 1
+                let res = bit_xor_public(&one, &zero_auth).open_authenticated().await.unwrap();
+                success = success && res == Scalar::one();
+
+                // 1 ^ 1 = 0
+                let res = bit_xor_public(&one, &one_auth).open_authenticated().await.unwrap();
+                success && res == Scalar::zero()
+            }
+        })
+        .await;
+
+        assert!(res)
+    }
+
+    /// Test the batch xor public gadget
+    #[tokio::test]
+    async fn test_xor_public_batch() {
+        const N: usize = 10;
+        let mut rng = thread_rng();
+        let a = (0..N).map(|_| Scalar::from(rng.gen_bool(0.5))).collect_vec();
+        let b = (0..N).map(|_| Scalar::from(rng.gen_bool(0.5))).collect_vec();
+
+        let expected_res =
+            a.iter().zip(b.iter()).map(|(a, b)| a + b - Scalar::from(2u64) * a * b).collect_vec();
+
+        let (res, _) = execute_mock_mpc(|fabric| {
+            let a = a.clone();
+            let b = b.clone();
+            async move {
+                let a = fabric.allocate_scalars(a);
+                let b = fabric.batch_share_scalar(b, PARTY0 /* sender */);
+                let res = bit_xor_public_batch(&a, &b);
+                let res_open = AuthenticatedScalarResult::open_authenticated_batch(&res);
+
+                future::join_all(res_open).await.into_iter().collect::<Result<Vec<_>, _>>()
+            }
+        })
+        .await;
+
+        assert_eq!(res.unwrap(), expected_res)
     }
 }


### PR DESCRIPTION
### Purpose
This PR optimizes the gate allocations in individual arithmetic gates on `AuthenticatedScalarResult`s. This largely reduces to combining computations on shares, macs, and public modifiers into a single gate. Given how many arithmetic ops are done in large circuits, this reduces the total number of gates substantially.

Reducing the number of gates is analogous to increasing the amount of work done per dequeue in the executor. This removes much of the overhead of the executor over a native execution.

I also added `xor` gadgets in this PR, pulled from `renegade/circuits`; they make more sense to optimize here.

### Testing
- Unit and integration tests pass