### PR TITLE
meta: Add `offline-phase`, `mp-spdz-rs`, and `MPC-SPDZ` libs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "MP-SPDZ"]
+	path = MP-SPDZ
+	url = https://github.com/renegade-fi/MP-SPDZ.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["online-phase"]
+members = ["mp-spdz-rs", "offline-phase", "online-phase"]
 
 [profile.bench]
 opt-level = 3

--- a/mp-spdz-rs/Cargo.toml
+++ b/mp-spdz-rs/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "mp-spdz-rs"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/mp-spdz-rs/src/lib.rs
+++ b/mp-spdz-rs/src/lib.rs
@@ -1,0 +1,7 @@
+//! Defines rust FFI bindings for the LowGear implementation in MP-SDPZ
+//! written in c++
+//!
+//! This library is intended to be a thin wrapper around the MP-SPDZ library,
+//! and to internalize build and link procedure with the foreign ABI
+
+// TODO: Implementation

--- a/offline-phase/Cargo.toml
+++ b/offline-phase/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "ark-mpc-offline"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/offline-phase/src/lib.rs
+++ b/offline-phase/src/lib.rs
@@ -1,0 +1,9 @@
+//! The `offline-phase` defines the low-gear SPDZ (https://eprint.iacr.org/2017/1230.pdf)
+//! implementation. This involves generating triples via a shallow FHE circuit
+//! and authenticating them via a ZKPoK and the classic SPDZ sacrifice protocol
+//!
+//! The offline phase runs ahead of any computation to setup a `BeaverSource` in
+//! the context of `ark-mpc`. This is done to ensure that the online phase may
+//! proceed efficiently without the need for complex public key primitives
+
+// TODO: Implementation


### PR DESCRIPTION
### Purpose
This PR adds additional repo structure ahead of the offline implementation:
- An `MP-SPDZ` submodule to the Renegade fork of `MP-SPDZ` which we will modify to support an FFI
- An `mpc-spdz-rs` library, which will add rust bindings for MP-SPDZ methods
- An `offline-phase` library, which will call MP-SPDZ bindings to implement the lowgear protocol

