### PR TITLE
mp-spdz-rs: build: Build FFI in `build.rs` file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "MP-SPDZ"]
-	path = MP-SPDZ
+[submodule "mp-spdz-rs/src/include/MP-SPDZ"]
+	path = mp-spdz-rs/src/include/MP-SPDZ
 	url = https://github.com/renegade-fi/MP-SPDZ.git

--- a/mp-spdz-rs/Cargo.toml
+++ b/mp-spdz-rs/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+cxx = "1.0"
+
+[build-dependencies]
+cxx-build = "1.0"
+itertools = "0.12.0"
+pkg-config = "0.3"

--- a/mp-spdz-rs/README.md
+++ b/mp-spdz-rs/README.md
@@ -1,0 +1,9 @@
+### Installation Steps
+1. Run `git submodule update --init --recursive` to clone the submodules in this repo.
+2. Install `libsodium` & `gmp` via:
+```zsh
+brew install libsodium gmp
+yum install libsodium gmp
+apt-get install libsodium gmp
+```
+based on your local package manager.

--- a/mp-spdz-rs/build.rs
+++ b/mp-spdz-rs/build.rs
@@ -1,0 +1,88 @@
+use itertools::Itertools;
+
+// Build entrypoint
+fn main() {
+    // Resolve the libsodium and gmp include paths
+    let libsodium_include = find_package("libsodium");
+    let gmp_include = find_package("gmp");
+
+    // Build the c++ bridge
+    cxx_build::bridge("src/lib.rs")
+        .file("src/include/MP-SPDZ/FHE/Ring_Element.cpp")
+        .include("src/include/MP-SPDZ")
+        .include("src/include/MP-SPDZ/deps")
+        .include(libsodium_include)
+        .include(gmp_include)
+        .std("c++17")
+        .compile("mp-spdz-cxx");
+
+    println!("cargo:rerun-if-changed=src/lib.rs");
+    println!("cargo:rerun-if-changed=../MP-SPDZ");
+}
+
+/// Get the vendor of the current host
+fn get_host_vendor() -> String {
+    let host_triple = get_host_triple();
+    host_triple[1].to_string()
+}
+
+/// Get the host triple
+fn get_host_triple() -> Vec<String> {
+    let host_triple = std::env::var("HOST").unwrap();
+    host_triple.split('-').map(|s| s.to_string()).collect_vec()
+}
+
+/// Resolve a package's include location
+///
+/// Windows is not supported
+fn find_package(name: &str) -> String {
+    let vendor = get_host_vendor();
+    if vendor == "apple" {
+        find_package_macos(name)
+    } else {
+        find_package_linux(name)
+    }
+}
+
+/// Find a package on macOS
+///
+/// For now we assume that the package is installed via `brew`
+fn find_package_macos(name: &str) -> String {
+    let output = std::process::Command::new("brew")
+        .arg("--prefix")
+        .arg(name)
+        .output()
+        .expect("error running `brew --prefix`");
+
+    // Check for a `brew` error
+    if !output.stderr.is_empty() {
+        panic!(
+            "\nPackage not found: {}\nTry running:\n\t `brew install {}`\n",
+            parse_utf8(&output.stderr),
+            name
+        );
+    }
+
+    // Parse the output from stdout
+    let path = parse_utf8(&output.stdout).trim().to_string();
+    format!("{path}/include")
+}
+
+/// Find a package on Linux
+fn find_package_linux(name: &str) -> String {
+    let conf = pkg_config::Config::new().probe(name);
+    match conf {
+        Ok(lib) => lib.include_paths[0].to_str().unwrap().to_string(),
+        Err(e) => {
+            panic!(
+                "Package not found: {}\nTry running:\n\t `{{apt-get, yum}} install {}`\n",
+                e, name
+            )
+        },
+    }
+}
+
+/// Parse a utf8 string from a byte array
+fn parse_utf8(bytes: &[u8]) -> String {
+    String::from_utf8(bytes.to_vec()).unwrap()
+}

--- a/mp-spdz-rs/src/lib.rs
+++ b/mp-spdz-rs/src/lib.rs
@@ -1,7 +1,29 @@
-//! Defines rust FFI bindings for the LowGear implementation in MP-SDPZ
+//! Defines rust FFI bindings for the LowGear implementation in MP-SPDZ
 //! written in c++
 //!
 //! This library is intended to be a thin wrapper around the MP-SPDZ library,
 //! and to internalize build and link procedure with the foreign ABI
 
-// TODO: Implementation
+#[cxx::bridge]
+pub mod ffi {
+    struct Test {
+        a: i32,
+        b: i32,
+    }
+
+    unsafe extern "C++" {
+        include!("FHE/Ring_Element.h");
+
+        fn test_method();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::ffi::test_method;
+
+    #[test]
+    fn test_dummy() {
+        test_method();
+    }
+}


### PR DESCRIPTION
### Purpose
This PR adds the initial `build.rs` script for the `mp-spdz-rs` module. This script:
- Find the `libsodium` and `gmp` paths (two shared libraries that MP-SPDZ requires) based on the host information.
- Build the cxx bridge targetting our sources

### Testing
- I added a dummy interface for now in the FFI, defining a `void test_method();` in `Ring_Element.h` of MP-SPDZ and verified that the binaries linked. The test method behaves as expected.