### PR TITLE
mp-spdz-rs: build: Link ntl, libsodium, and gmp into library object

### DIFF
--- a/mp-spdz-rs/README.md
+++ b/mp-spdz-rs/README.md
@@ -2,8 +2,8 @@
 1. Run `git submodule update --init --recursive` to clone the submodules in this repo.
 2. Install `libsodium` & `gmp` via:
 ```zsh
-brew install libsodium gmp
-yum install libsodium gmp
-apt-get install libsodium gmp
+brew install libsodium gmp boost ntl
+yum install libsodium gmp boost ntl
+apt-get install libsodium gmp boost ntl
 ```
 based on your local package manager.

--- a/mp-spdz-rs/src/lib.rs
+++ b/mp-spdz-rs/src/lib.rs
@@ -6,24 +6,20 @@
 
 #[cxx::bridge]
 pub mod ffi {
-    struct Test {
-        a: i32,
-        b: i32,
-    }
-
     unsafe extern "C++" {
-        include!("FHE/Ring_Element.h");
+        include!("FHE/Ring.h");
 
-        fn test_method();
+        type Ring;
+        fn new_ring(m: i32) -> UniquePtr<Ring>;
     }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::ffi::test_method;
+    use super::ffi::*;
 
     #[test]
     fn test_dummy() {
-        test_method();
+        let ring = new_ring(10);
     }
 }


### PR DESCRIPTION
### Purpose
This PR specifies the libraries that MP-SPDZ needs to link with and adds `cpp` files defining thread local values to the compiled source so that they may be resolved.

### Tesing
- Able to construct a `FHE/Ring` element using MP-SPDZ primitives