### PR TITLE
mp-spdz-rs: ffi: Add bindings for ciphertext <> plaintext ops

### DIFF
--- a/mp-spdz-rs/Cargo.toml
+++ b/mp-spdz-rs/Cargo.toml
@@ -3,7 +3,16 @@ name = "mp-spdz-rs"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+test-helpers = []
+
 [dependencies]
+# === Arithmetic + Crypto === #
+ark-ec = { version = "0.4", features = ["parallel"] }
+ark-ff = { version = "0.4", features = ["parallel"] }
+ark-mpc = { path = "../online-phase" }
+
+# === Bindings === #
 cxx = "1.0"
 
 [build-dependencies]
@@ -12,4 +21,5 @@ itertools = "0.12.0"
 pkg-config = "0.3"
 
 [dev-dependencies]
+ark-bn254 = "0.4"
 rand = "0.8.4"

--- a/mp-spdz-rs/build.rs
+++ b/mp-spdz-rs/build.rs
@@ -63,7 +63,7 @@ fn main() {
     }
 
     // Build cache flags
-    println!("cargo:rerun-if-changed=../MP-SPDZ");
+    println!("cargo:rerun-if-changed=src/include/MP-SPDZ");
 }
 
 /// Get the vendor of the current host

--- a/mp-spdz-rs/build.rs
+++ b/mp-spdz-rs/build.rs
@@ -64,6 +64,7 @@ fn main() {
 
     // Build cache flags
     println!("cargo:rerun-if-changed=src/include/MP-SPDZ");
+    println!("cargo:rerun-if-changed=src/ffi.rs");
 }
 
 /// Get the vendor of the current host

--- a/mp-spdz-rs/src/ffi.rs
+++ b/mp-spdz-rs/src/ffi.rs
@@ -38,6 +38,19 @@ mod ffi_inner {
         fn set_element_int(plaintext: Pin<&mut Plaintext_mod_prime>, idx: usize, value: u32);
         fn get_element_int(plaintext: &Plaintext_mod_prime, idx: usize) -> u32;
 
+        fn add_plaintexts(
+            x: &Plaintext_mod_prime,
+            y: &Plaintext_mod_prime,
+        ) -> UniquePtr<Plaintext_mod_prime>;
+        fn sub_plaintexts(
+            x: &Plaintext_mod_prime,
+            y: &Plaintext_mod_prime,
+        ) -> UniquePtr<Plaintext_mod_prime>;
+        fn mul_plaintexts(
+            x: &Plaintext_mod_prime,
+            y: &Plaintext_mod_prime,
+        ) -> UniquePtr<Plaintext_mod_prime>;
+
         // `Ciphertext`
         type Ciphertext;
         fn add_plaintext(c0: &Ciphertext, p1: &Plaintext_mod_prime) -> UniquePtr<Ciphertext>;
@@ -81,7 +94,7 @@ mod test {
         keypair: &FHE_KeyPair,
         params: &FHE_Params,
     ) -> UniquePtr<Ciphertext> {
-        let mut plaintext = plaintext_int(value, params);
+        let plaintext = plaintext_int(value, params);
         encrypt(keypair, &plaintext)
     }
 

--- a/mp-spdz-rs/src/fhe/ciphertext.rs
+++ b/mp-spdz-rs/src/fhe/ciphertext.rs
@@ -1,0 +1,200 @@
+//! Ciphertext wrapper around the MP-SPDZ `Ciphertext` struct
+
+use std::{
+    marker::PhantomData,
+    ops::{Add, Mul},
+};
+
+use ark_ec::CurveGroup;
+use cxx::UniquePtr;
+
+use crate::ffi::{
+    add_ciphertexts as ffi_add_cipher, add_plaintext as ffi_add_plaintext,
+    mul_ciphertexts as ffi_mul_ciphertext, mul_plaintext as ffi_mul_plaintext,
+    Ciphertext as FfiCiphertext,
+};
+
+use super::{keys::BGVPublicKey, plaintext::Plaintext};
+
+/// A ciphertext in the BGV implementation
+///
+/// The ciphertext is defined over the Scalar field of the curve group
+pub struct Ciphertext<C: CurveGroup> {
+    /// The wrapped MP-SPDZ `Ciphertext`
+    pub(crate) inner: UniquePtr<FfiCiphertext>,
+    /// Phantom
+    _phantom: PhantomData<C>,
+}
+
+impl<C: CurveGroup> Ciphertext<C> {
+    /// Multiply two ciphertexts
+    pub fn mul_ciphertext(&self, other: &Self, pk: &BGVPublicKey<C>) -> Self {
+        ffi_mul_ciphertext(self.as_ref(), other.as_ref(), pk.as_ref()).into()
+    }
+}
+
+impl<C: CurveGroup> From<UniquePtr<FfiCiphertext>> for Ciphertext<C> {
+    fn from(inner: UniquePtr<FfiCiphertext>) -> Self {
+        Self { inner, _phantom: PhantomData }
+    }
+}
+
+impl<C: CurveGroup> AsRef<FfiCiphertext> for Ciphertext<C> {
+    fn as_ref(&self) -> &FfiCiphertext {
+        self.inner.as_ref().unwrap()
+    }
+}
+
+impl<C: CurveGroup> Add<&Plaintext<C>> for &Ciphertext<C> {
+    type Output = Ciphertext<C>;
+
+    fn add(self, rhs: &Plaintext<C>) -> Self::Output {
+        ffi_add_plaintext(self.as_ref(), rhs.as_ref()).into()
+    }
+}
+
+impl<C: CurveGroup> Add for &Ciphertext<C> {
+    type Output = Ciphertext<C>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        ffi_add_cipher(self.as_ref(), rhs.as_ref()).into()
+    }
+}
+
+impl<C: CurveGroup> Mul<&Plaintext<C>> for &Ciphertext<C> {
+    type Output = Ciphertext<C>;
+
+    fn mul(self, rhs: &Plaintext<C>) -> Self::Output {
+        ffi_mul_plaintext(self.as_ref(), rhs.as_ref()).into()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use rand::{thread_rng, Rng, RngCore};
+
+    use crate::fhe::{keys::BGVKeypair, params::BGVParams, plaintext::Plaintext};
+    use crate::TestCurve;
+
+    use super::Ciphertext;
+
+    /// Setup the FHE scheme
+    fn setup_fhe() -> (BGVParams<TestCurve>, BGVKeypair<TestCurve>) {
+        let params = BGVParams::new(1 /* n_mults */);
+        let keypair = BGVKeypair::gen(&params);
+
+        (params, keypair)
+    }
+
+    /// Get a plaintext with the given value in the first slot
+    fn plaintext_int(val: u32, params: &BGVParams<TestCurve>) -> Plaintext<TestCurve> {
+        let mut plaintext = Plaintext::new(params);
+        plaintext.set_element(0, val);
+
+        plaintext
+    }
+
+    /// Get the ciphertext with the given value in the first slot
+    fn encrypt_int(
+        value: u32,
+        keypair: &BGVKeypair<TestCurve>,
+        params: &BGVParams<TestCurve>,
+    ) -> Ciphertext<TestCurve> {
+        let plaintext = plaintext_int(value, params);
+        keypair.encrypt(&plaintext)
+    }
+
+    /// Tests addition of a ciphertext with a plaintext
+    #[test]
+    fn test_ciphertext_plaintext_addition() {
+        let mut rng = thread_rng();
+        let (params, mut keypair) = setup_fhe();
+
+        // Add a ciphertext with a plaintext
+        let val1 = rng.next_u32() / 2;
+        let val2 = rng.next_u32() / 2;
+
+        let plaintext = plaintext_int(val2, &params);
+        let ciphertext = encrypt_int(val1, &keypair, &params);
+
+        let sum = &ciphertext + &plaintext;
+
+        // Decrypt the sum
+        let plaintext_res = keypair.decrypt(&sum);
+        let res = plaintext_res.get_element(0);
+        let expected = val1 + val2;
+
+        assert_eq!(res, expected);
+    }
+
+    /// Tests multiplication of a ciphertext with a plaintext
+    #[test]
+    fn test_ciphertext_plaintext_multiplication() {
+        let mut rng = thread_rng();
+        let (params, mut keypair) = setup_fhe();
+
+        // Multiply a ciphertext with a plaintext
+        let range = 0..(1u32 << 16);
+        let val1 = rng.gen_range(range.clone());
+        let val2 = rng.gen_range(range);
+
+        let plaintext = plaintext_int(val2, &params);
+        let ciphertext = encrypt_int(val1, &keypair, &params);
+
+        let product = &ciphertext * &plaintext;
+
+        // Decrypt the product
+        let plaintext_res = keypair.decrypt(&product);
+        let res = plaintext_res.get_element(0);
+        let expected = val1 * val2;
+
+        assert_eq!(res, expected);
+    }
+
+    /// Tests addition of two ciphertexts
+    #[test]
+    fn test_ciphertext_ciphertext_addition() {
+        let mut rng = thread_rng();
+        let (params, mut keypair) = setup_fhe();
+
+        // Add two ciphertexts
+        let val1 = rng.next_u32() / 2;
+        let val2 = rng.next_u32() / 2;
+
+        let ciphertext1 = encrypt_int(val1, &keypair, &params);
+        let ciphertext2 = encrypt_int(val2, &keypair, &params);
+
+        let sum = &ciphertext1 + &ciphertext2;
+
+        // Decrypt the sum
+        let plaintext_res = keypair.decrypt(&sum);
+        let res = plaintext_res.get_element(0);
+        let expected = val1 + val2;
+
+        assert_eq!(res, expected);
+    }
+
+    /// Tests multiplication of two ciphertexts
+    #[test]
+    fn test_ciphertext_ciphertext_multiplication() {
+        let mut rng = thread_rng();
+        let (params, mut keypair) = setup_fhe();
+
+        // Multiply two ciphertexts
+        let range = 0..(1u32 << 16);
+        let val1 = rng.gen_range(range.clone());
+        let val2 = rng.gen_range(range);
+
+        let ciphertext1 = encrypt_int(val1, &keypair, &params);
+        let ciphertext2 = encrypt_int(val2, &keypair, &params);
+
+        let product = ciphertext1.mul_ciphertext(&ciphertext2, &keypair.public_key);
+
+        // Decrypt the product
+        let plaintext_res = keypair.decrypt(&product);
+        let res = plaintext_res.get_element(0);
+        let expected = val1 * val2;
+
+        assert_eq!(res, expected);
+    }
+}

--- a/mp-spdz-rs/src/fhe/keys.rs
+++ b/mp-spdz-rs/src/fhe/keys.rs
@@ -1,0 +1,99 @@
+//! FHE keypair wrapper for the MP-SPDZ implementation
+
+use std::marker::PhantomData;
+
+use ark_ec::CurveGroup;
+use cxx::UniquePtr;
+
+use crate::ffi::{
+    decrypt as ffi_decrypt, encrypt as ffi_encrypt, get_pk as ffi_get_pk, get_sk as ffi_get_sk,
+    new_keypair as ffi_gen_keypair, FHE_KeyPair, FHE_PK, FHE_SK,
+};
+
+use super::{ciphertext::Ciphertext, params::BGVParams, plaintext::Plaintext};
+
+/// A public key in the BGV implementation
+pub struct BGVPublicKey<C: CurveGroup> {
+    /// The wrapped MP-SPDZ `PublicKey`
+    pub(crate) inner: UniquePtr<FHE_PK>,
+    /// Phantom
+    _phantom: PhantomData<C>,
+}
+
+impl<C: CurveGroup> AsRef<FHE_PK> for BGVPublicKey<C> {
+    fn as_ref(&self) -> &FHE_PK {
+        self.inner.as_ref().unwrap()
+    }
+}
+
+impl<C: CurveGroup> BGVPublicKey<C> {
+    /// Create a new public key
+    pub fn new(pk: UniquePtr<FHE_PK>) -> Self {
+        Self { inner: pk, _phantom: PhantomData }
+    }
+
+    /// Encrypt a plaintext
+    pub fn encrypt(&self, plaintext: &Plaintext<C>) -> Ciphertext<C> {
+        ffi_encrypt(self.as_ref(), plaintext.as_ref()).into()
+    }
+}
+
+/// A secret key in the BGV implementation
+pub struct BGVSecretKey<C: CurveGroup> {
+    /// The wrapped MP-SPDZ `SecretKey`
+    pub(crate) inner: UniquePtr<FHE_SK>,
+    /// Phantom
+    _phantom: PhantomData<C>,
+}
+
+impl<C: CurveGroup> AsRef<FHE_SK> for BGVSecretKey<C> {
+    fn as_ref(&self) -> &FHE_SK {
+        self.inner.as_ref().unwrap()
+    }
+}
+
+impl<C: CurveGroup> BGVSecretKey<C> {
+    /// Create a new secret key
+    pub fn new(sk: UniquePtr<FHE_SK>) -> Self {
+        Self { inner: sk, _phantom: PhantomData }
+    }
+
+    /// Decrypt a ciphertext
+    pub fn decrypt(&mut self, ciphertext: &Ciphertext<C>) -> Plaintext<C> {
+        ffi_decrypt(self.inner.pin_mut(), ciphertext.as_ref()).into()
+    }
+}
+
+/// A keypair in the BGV implementation
+pub struct BGVKeypair<C: CurveGroup> {
+    /// The public key
+    pub public_key: BGVPublicKey<C>,
+    /// The secret key
+    pub secret_key: BGVSecretKey<C>,
+}
+
+impl<C: CurveGroup> BGVKeypair<C> {
+    /// Create a new keypair
+    pub fn new(keypair: UniquePtr<FHE_KeyPair>) -> Self {
+        let pk = BGVPublicKey::new(ffi_get_pk(keypair.as_ref().unwrap()));
+        let sk = BGVSecretKey::new(ffi_get_sk(keypair.as_ref().unwrap()));
+
+        Self { public_key: pk, secret_key: sk }
+    }
+
+    /// Generate a keypair
+    pub fn gen(params: &BGVParams<C>) -> Self {
+        let keypair = ffi_gen_keypair(params.as_ref());
+        Self::new(keypair)
+    }
+
+    /// Encrypt a plaintext
+    pub fn encrypt(&self, plaintext: &Plaintext<C>) -> Ciphertext<C> {
+        self.public_key.encrypt(plaintext)
+    }
+
+    /// Decrypt a ciphertext
+    pub fn decrypt(&mut self, ciphertext: &Ciphertext<C>) -> Plaintext<C> {
+        self.secret_key.decrypt(ciphertext)
+    }
+}

--- a/mp-spdz-rs/src/fhe/mod.rs
+++ b/mp-spdz-rs/src/fhe/mod.rs
@@ -1,0 +1,6 @@
+//! FHE primitives exported from MP-SPDZ
+//!
+//! Implements the BGV cryptosystem
+
+pub mod params;
+pub mod plaintext;

--- a/mp-spdz-rs/src/fhe/mod.rs
+++ b/mp-spdz-rs/src/fhe/mod.rs
@@ -2,5 +2,7 @@
 //!
 //! Implements the BGV cryptosystem
 
+pub mod ciphertext;
+pub mod keys;
 pub mod params;
 pub mod plaintext;

--- a/mp-spdz-rs/src/fhe/params.rs
+++ b/mp-spdz-rs/src/fhe/params.rs
@@ -1,0 +1,44 @@
+//! FHE setup parameters
+
+use ark_ec::CurveGroup;
+use ark_mpc::algebra::Scalar;
+use std::marker::PhantomData;
+
+use cxx::UniquePtr;
+
+use crate::ffi::{new_fhe_params, FHE_Params};
+
+/// The default drowning security parameter
+const DEFAULT_DROWN_SEC: i32 = 128;
+
+/// A wrapper around the MP-SPDZ `FHE_Params` struct
+pub struct BGVParams<C: CurveGroup> {
+    /// The wrapped MP-SPDZ `FHE_Params`
+    pub(crate) inner: UniquePtr<FHE_Params>,
+    /// Phantom
+    _phantom: PhantomData<C>,
+}
+
+impl<C: CurveGroup> AsRef<FHE_Params> for BGVParams<C> {
+    fn as_ref(&self) -> &FHE_Params {
+        self.inner.as_ref().unwrap()
+    }
+}
+
+impl<C: CurveGroup> BGVParams<C> {
+    /// Create a new set of FHE parameters
+    pub fn new(n_mults: u32) -> Self {
+        let mut inner = new_fhe_params(n_mults as i32, DEFAULT_DROWN_SEC);
+
+        // Generate the parameters
+        let bits = Scalar::<C>::bit_length() as i32;
+        inner.pin_mut().basic_generation_mod_prime(bits);
+
+        Self { inner, _phantom: PhantomData }
+    }
+
+    /// Create a new set of FHE parameters that supports zero multiplications
+    pub fn new_no_mults() -> Self {
+        Self::new(0)
+    }
+}

--- a/mp-spdz-rs/src/fhe/plaintext.rs
+++ b/mp-spdz-rs/src/fhe/plaintext.rs
@@ -1,0 +1,148 @@
+//! Wrapper around an MP-SPDZ plaintext that exports a rust-friendly interface
+
+use std::{
+    marker::PhantomData,
+    ops::{Add, Mul, Sub},
+};
+
+use ark_ec::CurveGroup;
+use cxx::UniquePtr;
+
+use crate::ffi::{
+    add_plaintexts, get_element_int, mul_plaintexts, new_plaintext, set_element_int,
+    sub_plaintexts, Plaintext_mod_prime,
+};
+
+use super::params::BGVParams;
+
+/// A plaintext in the BGV implementation
+///
+/// The plaintext is defined over the Scalar field of the curve group
+pub struct Plaintext<C: CurveGroup> {
+    /// The wrapped MP-SPDZ `Plaintext_mod_prime`
+    inner: UniquePtr<Plaintext_mod_prime>,
+    /// Phantom
+    _phantom: PhantomData<C>,
+}
+
+impl<C: CurveGroup> AsRef<Plaintext_mod_prime> for Plaintext<C> {
+    fn as_ref(&self) -> &Plaintext_mod_prime {
+        self.inner.as_ref().unwrap()
+    }
+}
+
+impl<C: CurveGroup> Plaintext<C> {
+    /// Create a new plaintext
+    pub fn new(params: &BGVParams<C>) -> Self {
+        let inner = new_plaintext(params.as_ref());
+        Self { inner, _phantom: PhantomData }
+    }
+
+    /// Set the value of an element in the plaintext
+    pub fn set_element(&mut self, idx: usize, value: u32) {
+        set_element_int(self.inner.pin_mut(), idx, value)
+    }
+
+    /// Get the value of an element in the plaintext
+    pub fn get_element(&self, idx: usize) -> u32 {
+        get_element_int(self.as_ref(), idx)
+    }
+}
+
+impl<C: CurveGroup> From<UniquePtr<Plaintext_mod_prime>> for Plaintext<C> {
+    fn from(inner: UniquePtr<Plaintext_mod_prime>) -> Self {
+        Self { inner, _phantom: PhantomData }
+    }
+}
+
+// --------------
+// | Arithmetic |
+// --------------
+
+impl<C: CurveGroup> Add for &Plaintext<C> {
+    type Output = Plaintext<C>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        add_plaintexts(self.as_ref(), rhs.as_ref()).into()
+    }
+}
+impl<C: CurveGroup> Sub for &Plaintext<C> {
+    type Output = Plaintext<C>;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        sub_plaintexts(self.as_ref(), rhs.as_ref()).into()
+    }
+}
+
+impl<C: CurveGroup> Mul<&Plaintext<C>> for &Plaintext<C> {
+    type Output = Plaintext<C>;
+
+    fn mul(self, rhs: &Plaintext<C>) -> Self::Output {
+        mul_plaintexts(self.as_ref(), rhs.as_ref()).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::{thread_rng, Rng, RngCore};
+
+    use super::*;
+    use crate::TestCurve;
+
+    /// A helper to get parameters for the tests
+    fn get_params() -> BGVParams<TestCurve> {
+        BGVParams::new(1 /* n_mults */)
+    }
+
+    #[test]
+    fn test_add() {
+        let mut rng = thread_rng();
+        let params = get_params();
+        let val1 = rng.next_u32() / 2;
+        let val2 = rng.next_u32() / 2;
+
+        let mut plaintext1 = Plaintext::new(&params);
+        let mut plaintext2 = Plaintext::new(&params);
+        plaintext1.set_element(0, val1);
+        plaintext2.set_element(0, val2);
+
+        let expected = val1 + val2;
+        let result = &plaintext1 + &plaintext2;
+        assert_eq!(result.get_element(0), expected);
+    }
+
+    #[test]
+    fn test_sub() {
+        let mut rng = thread_rng();
+        let params = get_params();
+        let val1 = rng.next_u32();
+        let val2 = rng.gen_range(0..val1);
+
+        let mut plaintext1 = Plaintext::new(&params);
+        let mut plaintext2 = Plaintext::new(&params);
+        plaintext1.set_element(0, val1);
+        plaintext2.set_element(0, val2);
+
+        let expected = val1 - val2;
+        let result = &plaintext1 - &plaintext2;
+        assert_eq!(result.get_element(0), expected);
+    }
+
+    #[test]
+    fn test_mul() {
+        let mut rng = thread_rng();
+        let params = get_params();
+        let range = 0..(1u32 << 16);
+        let val1 = rng.gen_range(range.clone());
+        let val2 = rng.gen_range(range);
+
+        let mut plaintext1 = Plaintext::new(&params);
+        let mut plaintext2 = Plaintext::new(&params);
+        plaintext1.set_element(0, val1);
+        plaintext2.set_element(0, val2);
+
+        let expected = val1 * val2;
+        let result = &plaintext1 * &plaintext2;
+        assert_eq!(result.get_element(0), expected);
+    }
+}

--- a/mp-spdz-rs/src/lib.rs
+++ b/mp-spdz-rs/src/lib.rs
@@ -5,3 +5,12 @@
 //! and to internalize build and link procedure with the foreign ABI
 
 pub mod ffi;
+pub mod fhe;
+
+#[cfg(test)]
+mod test_helpers {
+    /// The curve group to use for testing
+    pub type TestCurve = ark_bn254::G1Projective;
+}
+#[cfg(test)]
+pub(crate) use test_helpers::*;

--- a/mp-spdz-rs/src/lib.rs
+++ b/mp-spdz-rs/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod ffi;
 pub mod fhe;
 
+#[allow(clippy::items_after_test_module)]
 #[cfg(test)]
 mod test_helpers {
     /// The curve group to use for testing

--- a/online-phase/src/algebra/scalar/scalar.rs
+++ b/online-phase/src/algebra/scalar/scalar.rs
@@ -68,6 +68,11 @@ impl<C: CurveGroup> Scalar<C> {
         self.0
     }
 
+    /// Get the bit length of the scalar
+    pub fn bit_length() -> usize {
+        C::ScalarField::MODULUS_BIT_SIZE as usize
+    }
+
     /// Sample a random field element
     pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         Self(C::ScalarField::rand(rng))


### PR DESCRIPTION
### Purpose
This PR adds FFI bindings for operations between plaintexts and ciphertexts; specifically add and multiply.

### Testing
- Unit tests pass