### PR TITLE
mp-spdz-rs: fhe: Setup params using `CurveGroup`'s scalar field modulus

### DIFF
--- a/mp-spdz-rs/src/ffi.rs
+++ b/mp-spdz-rs/src/ffi.rs
@@ -19,6 +19,7 @@ mod ffi_inner {
         type FHE_Params;
         fn new_fhe_params(n_mults: i32, drown_sec: i32) -> UniquePtr<FHE_Params>;
         fn basic_generation_mod_prime(self: Pin<&mut FHE_Params>, plaintext_length: i32);
+        fn param_generation_with_modulus(self: Pin<&mut FHE_Params>, plaintext_modulus: &bigint);
         fn get_plaintext_mod(params: &FHE_Params) -> UniquePtr<bigint>;
 
         // `FHE Keys`

--- a/mp-spdz-rs/src/fhe/ciphertext.rs
+++ b/mp-spdz-rs/src/fhe/ciphertext.rs
@@ -72,7 +72,7 @@ impl<C: CurveGroup> Mul<&Plaintext<C>> for &Ciphertext<C> {
 #[cfg(test)]
 mod test {
     use ark_mpc::algebra::Scalar;
-    use rand::{thread_rng, RngCore};
+    use rand::thread_rng;
 
     use crate::fhe::{keys::BGVKeypair, params::BGVParams, plaintext::Plaintext};
     use crate::TestCurve;
@@ -115,8 +115,8 @@ mod test {
         let (params, mut keypair) = setup_fhe();
 
         // Add a ciphertext with a plaintext
-        let val1 = rng.next_u64().into();
-        let val2 = rng.next_u64().into();
+        let val1 = Scalar::random(&mut rng);
+        let val2 = Scalar::random(&mut rng);
 
         let plaintext = plaintext_int(val2, &params);
         let ciphertext = encrypt_int(val1, &keypair, &params);
@@ -138,8 +138,8 @@ mod test {
         let (params, mut keypair) = setup_fhe();
 
         // Multiply a ciphertext with a plaintext
-        let val1 = rng.next_u64().into();
-        let val2 = rng.next_u64().into();
+        let val1 = Scalar::random(&mut rng);
+        let val2 = Scalar::random(&mut rng);
 
         let plaintext = plaintext_int(val2, &params);
         let ciphertext = encrypt_int(val1, &keypair, &params);
@@ -161,8 +161,8 @@ mod test {
         let (params, mut keypair) = setup_fhe();
 
         // Add two ciphertexts
-        let val1 = rng.next_u64().into();
-        let val2 = rng.next_u64().into();
+        let val1 = Scalar::random(&mut rng);
+        let val2 = Scalar::random(&mut rng);
 
         let ciphertext1 = encrypt_int(val1, &keypair, &params);
         let ciphertext2 = encrypt_int(val2, &keypair, &params);
@@ -184,8 +184,8 @@ mod test {
         let (params, mut keypair) = setup_fhe();
 
         // Multiply two ciphertexts
-        let val1 = rng.next_u64().into();
-        let val2 = rng.next_u64().into();
+        let val1 = Scalar::random(&mut rng);
+        let val2 = Scalar::random(&mut rng);
 
         let ciphertext1 = encrypt_int(val1, &keypair, &params);
         let ciphertext2 = encrypt_int(val2, &keypair, &params);

--- a/mp-spdz-rs/src/fhe/plaintext.rs
+++ b/mp-spdz-rs/src/fhe/plaintext.rs
@@ -87,7 +87,7 @@ impl<C: CurveGroup> Mul<&Plaintext<C>> for &Plaintext<C> {
 
 #[cfg(test)]
 mod tests {
-    use rand::{thread_rng, RngCore};
+    use rand::thread_rng;
 
     use super::*;
     use crate::TestCurve;
@@ -101,8 +101,8 @@ mod tests {
     fn test_add() {
         let mut rng = thread_rng();
         let params = get_params();
-        let val1: Scalar<TestCurve> = rng.next_u64().into();
-        let val2: Scalar<TestCurve> = rng.next_u32().into();
+        let val1: Scalar<TestCurve> = Scalar::random(&mut rng);
+        let val2: Scalar<TestCurve> = Scalar::random(&mut rng);
 
         let mut plaintext1 = Plaintext::new(&params);
         let mut plaintext2 = Plaintext::new(&params);
@@ -118,8 +118,8 @@ mod tests {
     fn test_sub() {
         let mut rng = thread_rng();
         let params = get_params();
-        let val1: Scalar<TestCurve> = rng.next_u64().into();
-        let val2: Scalar<TestCurve> = rng.next_u32().into();
+        let val1: Scalar<TestCurve> = Scalar::random(&mut rng);
+        let val2: Scalar<TestCurve> = Scalar::random(&mut rng);
 
         let mut plaintext1 = Plaintext::new(&params);
         let mut plaintext2 = Plaintext::new(&params);
@@ -135,8 +135,8 @@ mod tests {
     fn test_mul() {
         let mut rng = thread_rng();
         let params = get_params();
-        let val1: Scalar<TestCurve> = rng.next_u64().into();
-        let val2: Scalar<TestCurve> = rng.next_u64().into();
+        let val1: Scalar<TestCurve> = Scalar::random(&mut rng);
+        let val2: Scalar<TestCurve> = Scalar::random(&mut rng);
 
         let mut plaintext1 = Plaintext::new(&params);
         let mut plaintext2 = Plaintext::new(&params);


### PR DESCRIPTION
### Purpose
This PR sets up the FHE params using a plaintext modulus equal to the modulus of the `CurveGroup`'s scalar field. This allows us to do full `Scalar` arithmetic with correct residue behavior.

### Testing
- Removed all bitlength bounds on tests, tests pass