### PR TITLE
mp-spdz-rs: Implement serialization for all basic types

### DIFF
--- a/mp-spdz-rs/Cargo.toml
+++ b/mp-spdz-rs/Cargo.toml
@@ -28,6 +28,7 @@ cxx = "1.0"
 
 # === Misc === #
 rand = { version = "0.8.4", optional = true }
+serde = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
 cxx-build = "1.0"
@@ -38,3 +39,4 @@ pkg-config = "0.3"
 ark-bn254 = "0.4"
 criterion = { version = "0.5", features = ["async", "async_tokio"] }
 rand = "0.8.4"
+serde_json = "1.0"

--- a/mp-spdz-rs/benches/ciphertext_ops.rs
+++ b/mp-spdz-rs/benches/ciphertext_ops.rs
@@ -128,7 +128,7 @@ fn bench_ciphertext_multiplication(c: &mut Criterion) {
                 let ciphertext2 = keypair.encrypt(&random_plaintext(&params));
 
                 let start = std::time::Instant::now();
-                let _ = &ciphertext1.mul_ciphertext(&ciphertext2, &keypair.public_key);
+                let _ = &ciphertext1.mul_ciphertext(&ciphertext2, &keypair.public_key());
                 total_time += start.elapsed();
             }
 

--- a/mp-spdz-rs/src/ffi.rs
+++ b/mp-spdz-rs/src/ffi.rs
@@ -23,6 +23,9 @@ mod ffi_inner {
         type FHE_Params;
         fn new_fhe_params(n_mults: i32, drown_sec: i32) -> UniquePtr<FHE_Params>;
         fn clone(self: &FHE_Params) -> UniquePtr<FHE_Params>;
+        fn to_rust_bytes(self: &FHE_Params) -> Vec<u8>;
+        fn fhe_params_from_rust_bytes(data: &[u8]) -> UniquePtr<FHE_Params>;
+
         fn n_plaintext_slots(self: &FHE_Params) -> u32;
         fn basic_generation_mod_prime(self: Pin<&mut FHE_Params>, plaintext_length: i32);
         fn param_generation_with_modulus(self: Pin<&mut FHE_Params>, plaintext_modulus: &bigint);
@@ -33,9 +36,18 @@ mod ffi_inner {
         type FHE_PK;
         type FHE_SK;
         fn new_keypair(params: &FHE_Params) -> UniquePtr<FHE_KeyPair>;
+
         fn clone(self: &FHE_KeyPair) -> UniquePtr<FHE_KeyPair>;
         fn clone(self: &FHE_PK) -> UniquePtr<FHE_PK>;
         fn clone(self: &FHE_SK) -> UniquePtr<FHE_SK>;
+
+        fn to_rust_bytes(self: &FHE_PK) -> Vec<u8>;
+        fn to_rust_bytes(self: &FHE_SK) -> Vec<u8>;
+        fn to_rust_bytes(self: &FHE_KeyPair) -> Vec<u8>;
+
+        fn pk_from_rust_bytes(data: &[u8], params: &FHE_Params) -> UniquePtr<FHE_PK>;
+        fn sk_from_rust_bytes(data: &[u8], params: &FHE_Params) -> UniquePtr<FHE_SK>;
+        fn keypair_from_rust_bytes(data: &[u8], params: &FHE_Params) -> UniquePtr<FHE_KeyPair>;
 
         fn get_pk(keypair: &FHE_KeyPair) -> UniquePtr<FHE_PK>;
         fn get_sk(keypair: &FHE_KeyPair) -> UniquePtr<FHE_SK>;
@@ -47,6 +59,12 @@ mod ffi_inner {
         type Plaintext_mod_prime;
         fn new_plaintext(params: &FHE_Params) -> UniquePtr<Plaintext_mod_prime>;
         fn clone(self: &Plaintext_mod_prime) -> UniquePtr<Plaintext_mod_prime>;
+        fn to_rust_bytes(self: &Plaintext_mod_prime) -> Vec<u8>;
+        fn plaintext_from_rust_bytes(
+            data: &[u8],
+            params: &FHE_Params,
+        ) -> UniquePtr<Plaintext_mod_prime>;
+
         fn num_slots(self: &Plaintext_mod_prime) -> u32;
         fn get_element_int(plaintext: &Plaintext_mod_prime, idx: usize) -> u32;
         fn set_element_int(plaintext: Pin<&mut Plaintext_mod_prime>, idx: usize, value: u32);
@@ -69,6 +87,9 @@ mod ffi_inner {
         // `Ciphertext`
         type Ciphertext;
         fn clone(self: &Ciphertext) -> UniquePtr<Ciphertext>;
+        fn to_rust_bytes(self: &Ciphertext) -> Vec<u8>;
+        fn ciphertext_from_rust_bytes(data: &[u8], params: &FHE_Params) -> UniquePtr<Ciphertext>;
+
         fn add_plaintext(c0: &Ciphertext, p1: &Plaintext_mod_prime) -> UniquePtr<Ciphertext>;
         fn mul_plaintext(c0: &Ciphertext, p1: &Plaintext_mod_prime) -> UniquePtr<Ciphertext>;
         fn add_ciphertexts(c0: &Ciphertext, c1: &Ciphertext) -> UniquePtr<Ciphertext>;

--- a/mp-spdz-rs/src/lib.rs
+++ b/mp-spdz-rs/src/lib.rs
@@ -13,14 +13,34 @@
 pub mod ffi;
 pub mod fhe;
 
+/// A trait for serializing to bytes
+pub trait ToBytes {
+    /// Serialize to bytes
+    fn to_bytes(&self) -> Vec<u8>;
+}
+
+/// A trait for deserializing from bytes with BGV parameters in scope
+pub trait FromBytesWithParams<C: CurveGroup> {
+    /// Deserialize from bytes
+    fn from_bytes(data: &[u8], params: &BGVParams<C>) -> Self;
+}
+
 #[allow(clippy::items_after_test_module)]
 #[cfg(any(test, feature = "test-helpers"))]
 mod test_helpers {
     //! Helper methods for unit tests
+    use super::ToBytes;
 
     /// The curve group to use for testing
     pub type TestCurve = ark_bn254::G1Projective;
+
+    /// Compare two values by byte-serializing them
+    pub fn compare_bytes<T: ToBytes>(a: &T, b: &T) -> bool {
+        a.to_bytes() == b.to_bytes()
+    }
 }
+use ark_ec::CurveGroup;
+use fhe::params::BGVParams;
 #[cfg(any(test, feature = "test-helpers"))]
 pub use test_helpers::*;
 


### PR DESCRIPTION
### Purpose
This PR implements serialization for all basic types in the FHE interface. This is done ahead of the offline phase implementation which largely revolves around communicating ciphertexts between parties.

Note that most of these serialization implementations require the `BGVParams` in scope to deserialize correct for field sizing, etc. For this reason, we don't use `serde` interfaces directly on most types. Instead we will couple and colocate these types with `BGVParams` at higher levels of abstraction to ensure that a params instance is always in scope when necessary.

### Testing
- Tested all serde implementations