### PR TITLE
offline-phase: Setup initial offline phase protocol execution

### DIFF
--- a/mp-spdz-rs/build.rs
+++ b/mp-spdz-rs/build.rs
@@ -82,12 +82,12 @@ fn get_host_triple() -> Vec<String> {
 /// Add a link path to the linker
 fn add_link_path(lib: &str) {
     let lib_path = find_lib_path(lib);
-    println!("cargo:rustc-link-arg=-L{}", lib_path);
+    println!("cargo:rustc-link-search={lib_path}");
 }
 
 /// Link a library into the object
 fn link_lib(lib: &str) {
-    println!("cargo:rustc-link-arg=-l{}", lib);
+    println!("cargo:rustc-link-lib=static={lib}");
 }
 
 /// Find the include location for a package

--- a/mp-spdz-rs/src/ffi.rs
+++ b/mp-spdz-rs/src/ffi.rs
@@ -97,6 +97,11 @@ mod ffi_inner {
     }
 }
 pub use ffi_inner::*;
+unsafe impl Send for FHE_Params {}
+unsafe impl Send for FHE_KeyPair {}
+unsafe impl Send for FHE_PK {}
+unsafe impl Send for Ciphertext {}
+unsafe impl Send for Plaintext_mod_prime {}
 
 #[cfg(test)]
 mod test {

--- a/mp-spdz-rs/src/fhe/plaintext.rs
+++ b/mp-spdz-rs/src/fhe/plaintext.rs
@@ -72,6 +72,14 @@ impl<C: CurveGroup> Plaintext<C> {
         self.inner.num_slots()
     }
 
+    /// Set each slot with the given value
+    pub fn set_all(&mut self, value: Scalar<C>) {
+        let val_bigint = scalar_to_ffi_bigint(value);
+        for i in 0..self.num_slots() {
+            set_element_bigint(self.inner.pin_mut(), i as usize, val_bigint.as_ref().unwrap());
+        }
+    }
+
     /// Set the value of an element in the plaintext
     pub fn set_element(&mut self, idx: usize, value: Scalar<C>) {
         let val_bigint = scalar_to_ffi_bigint(value);

--- a/offline-phase/Cargo.toml
+++ b/offline-phase/Cargo.toml
@@ -4,3 +4,20 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+# === Crypto + Arithmetic === #
+ark-ec = "0.4"
+ark-ff = "0.4"
+ark-mpc = { path = "../online-phase" }
+
+mp-spdz-rs = { path = "../mp-spdz-rs" }
+
+# === Runtime + Network === #
+futures = "0.3"
+
+# === Misc Dependencies === #
+rand = "0.8"
+
+[dev-dependencies]
+ark-bn254 = "0.4"
+ark-mpc = { path = "../online-phase", features = ["test_helpers"] }
+tokio = { version = "1", features = ["full"] }

--- a/offline-phase/src/beaver_source.rs
+++ b/offline-phase/src/beaver_source.rs
@@ -1,0 +1,22 @@
+//! Defines the result of the Lowgear offline phase
+
+use ark_ec::CurveGroup;
+use ark_mpc::algebra::Scalar;
+use mp_spdz_rs::fhe::ciphertext::Ciphertext;
+use mp_spdz_rs::fhe::keys::{BGVKeypair, BGVPublicKey};
+use mp_spdz_rs::fhe::params::BGVParams;
+
+/// The parameters setup by the offline phase
+#[derive(Clone)]
+pub struct LowGearParams<C: CurveGroup> {
+    /// The local party's BGV keypair
+    pub local_keypair: BGVKeypair<C>,
+    /// The local party's MAC key share
+    pub mac_key_share: Scalar<C>,
+    /// The BGV public key of the counterparty
+    pub other_pk: BGVPublicKey<C>,
+    /// An encryption of the counterparty's MAC key share
+    pub other_mac_enc: Ciphertext<C>,
+    /// The BGV cryptosystem parameters
+    pub bgv_params: BGVParams<C>,
+}

--- a/offline-phase/src/error.rs
+++ b/offline-phase/src/error.rs
@@ -1,0 +1,27 @@
+//! Error types for the offline phase
+use std::{error::Error, fmt::Display};
+
+/// The error types for the offline phase
+#[derive(Clone, Debug)]
+pub enum LowGearError {
+    /// Error exchanging keys
+    KeyExchange(String),
+    /// The lowgear setup params requested before setup
+    NotSetup,
+    /// An error while sending a message
+    SendMessage(String),
+    /// Received an unexpected message
+    UnexpectedMessage(String),
+}
+
+impl Display for LowGearError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LowGearError::KeyExchange(e) => write!(f, "Key exchange error: {e}"),
+            LowGearError::NotSetup => write!(f, "LowGear not setup"),
+            LowGearError::SendMessage(e) => write!(f, "Error sending message: {e}"),
+            LowGearError::UnexpectedMessage(e) => write!(f, "Unexpected message: {e}"),
+        }
+    }
+}
+impl Error for LowGearError {}

--- a/offline-phase/src/lib.rs
+++ b/offline-phase/src/lib.rs
@@ -6,4 +6,50 @@
 //! the context of `ark-mpc`. This is done to ensure that the online phase may
 //! proceed efficiently without the need for complex public key primitives
 
-// TODO: Implementation
+#![deny(unsafe_code)]
+#![deny(missing_docs)]
+#![deny(clippy::missing_docs_in_private_items)]
+#![allow(incomplete_features)]
+#![allow(ambiguous_glob_reexports)]
+#![feature(inherent_associated_types)]
+#![feature(stmt_expr_attributes)]
+
+pub mod beaver_source;
+pub mod error;
+pub mod lowgear;
+
+#[cfg(test)]
+pub(crate) mod test_helpers {
+    use ark_mpc::{
+        network::{MockNetwork, UnboundedDuplexStream},
+        PARTY0, PARTY1,
+    };
+    use futures::Future;
+
+    use crate::lowgear::LowGear;
+
+    /// The curve used for testing in this crate
+    pub type TestCurve = ark_bn254::G1Projective;
+
+    /// Run a two-party method with a `LowGear` instance setup and in scope
+    pub async fn mock_lowgear<F, S, T>(mut f: F) -> (T, T)
+    where
+        T: Send + 'static,
+        S: Future<Output = T> + Send + 'static,
+        F: FnMut(LowGear<TestCurve, MockNetwork<TestCurve>>) -> S,
+    {
+        let (stream1, stream2) = UnboundedDuplexStream::new_duplex_pair();
+        let net1 = MockNetwork::new(PARTY0, stream1);
+        let net2 = MockNetwork::new(PARTY1, stream2);
+
+        let lowgear1 = LowGear::new(net1);
+        let lowgear2 = LowGear::new(net2);
+
+        let task1 = tokio::spawn(f(lowgear1));
+        let task2 = tokio::spawn(f(lowgear2));
+        let party0_out = task1.await.unwrap();
+        let party1_out = task2.await.unwrap();
+
+        (party0_out, party1_out)
+    }
+}

--- a/offline-phase/src/lowgear/mod.rs
+++ b/offline-phase/src/lowgear/mod.rs
@@ -1,0 +1,132 @@
+//! Defines the lowgear protocol for generating triples, inverse pairs, mac
+//! keys, authenticating inputs, etc
+
+pub mod setup;
+
+use ark_ec::CurveGroup;
+use ark_mpc::{
+    algebra::Scalar,
+    network::{MpcNetwork, NetworkOutbound, NetworkPayload},
+};
+use futures::{SinkExt, StreamExt};
+use mp_spdz_rs::{
+    fhe::{
+        ciphertext::Ciphertext,
+        keys::{BGVKeypair, BGVPublicKey},
+        params::BGVParams,
+    },
+    FromBytesWithParams, ToBytes,
+};
+use rand::thread_rng;
+
+use crate::{beaver_source::LowGearParams, error::LowGearError};
+
+/// A type implementing Lowgear protocol logic
+pub struct LowGear<C: CurveGroup, N: MpcNetwork<C>> {
+    /// The parameters for the BGV scheme
+    pub params: BGVParams<C>,
+    /// The BGV keypair used by the local party
+    pub local_keypair: BGVKeypair<C>,
+    /// The local party's MAC key share
+    pub mac_share: Scalar<C>,
+    /// The BGV public key of the counterparty
+    pub other_pk: Option<BGVPublicKey<C>>,
+    /// An encryption of the counterparty's MAC key share under their public key
+    pub other_mac_enc: Option<Ciphertext<C>>,
+    /// A reference to the underlying network connection
+    pub network: N,
+}
+
+impl<C: CurveGroup, N: MpcNetwork<C> + Unpin> LowGear<C, N> {
+    /// Create a new LowGear instance
+    #[allow(clippy::new_without_default)]
+    pub fn new(network: N) -> Self {
+        let mut rng = thread_rng();
+        let params = BGVParams::new_no_mults();
+        let local_keypair = BGVKeypair::gen(&params);
+        let mac_share = Scalar::random(&mut rng);
+
+        Self { params, local_keypair, mac_share, other_pk: None, other_mac_enc: None, network }
+    }
+
+    /// Get the setup parameters from the offline phase
+    pub fn get_setup_params(&self) -> Result<LowGearParams<C>, LowGearError> {
+        Ok(LowGearParams {
+            local_keypair: self.local_keypair.clone(),
+            mac_key_share: self.mac_share,
+            other_pk: self.other_pk.clone().ok_or(LowGearError::NotSetup)?,
+            other_mac_enc: self.other_mac_enc.clone().ok_or(LowGearError::NotSetup)?,
+            bgv_params: self.params.clone(),
+        })
+    }
+
+    /// Send a message to the counterparty
+    pub async fn send_message<T: ToBytes>(&mut self, message: T) -> Result<(), LowGearError> {
+        let payload = NetworkPayload::<C>::Bytes(message.to_bytes());
+        let msg = NetworkOutbound { result_id: 0, payload };
+
+        self.network.send(msg).await.map_err(|e| LowGearError::SendMessage(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Receive a message from the counterparty
+    pub async fn receive_message<T: FromBytesWithParams<C>>(&mut self) -> Result<T, LowGearError> {
+        let msg = self.network.next().await.unwrap().unwrap();
+        let payload = match msg.payload {
+            NetworkPayload::Bytes(bytes) => bytes,
+            _ => return Err(LowGearError::UnexpectedMessage(format!("{:?}", msg.payload))),
+        };
+
+        Ok(T::from_bytes(&payload, &self.params))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ark_mpc::{network::MpcNetwork, test_helpers::TestCurve, PARTY0};
+    use mp_spdz_rs::{fhe::params::BGVParams, FromBytesWithParams, ToBytes};
+
+    use crate::test_helpers::mock_lowgear;
+
+    /// A test message type
+    #[derive(Clone, Debug)]
+    struct TestMessage(String);
+    impl ToBytes for TestMessage {
+        fn to_bytes(&self) -> Vec<u8> {
+            self.0.as_bytes().to_vec()
+        }
+    }
+
+    impl FromBytesWithParams<TestCurve> for TestMessage {
+        fn from_bytes(data: &[u8], _params: &BGVParams<TestCurve>) -> Self {
+            Self(String::from_utf8(data.to_vec()).unwrap())
+        }
+    }
+
+    /// Tests sending and receiving a message
+    #[tokio::test]
+    async fn test_send_receive() {
+        const MSG1: &str = "Party 0 to Party 1";
+        const MSG2: &str = "Party 1 to Party 0";
+
+        let (res1, res2) = mock_lowgear(|mut lowgear| async move {
+            let party = lowgear.network.party_id();
+            if party == PARTY0 {
+                let msg = TestMessage(MSG1.to_string());
+                lowgear.send_message(msg).await.unwrap();
+                lowgear.receive_message::<TestMessage>().await.unwrap()
+            } else {
+                let msg = TestMessage(MSG2.to_string());
+                let recv = lowgear.receive_message::<TestMessage>().await.unwrap();
+                lowgear.send_message(msg).await.unwrap();
+
+                recv
+            }
+        })
+        .await;
+
+        // Check the results
+        assert_eq!(res1.0, MSG2);
+        assert_eq!(res2.0, MSG1);
+    }
+}

--- a/offline-phase/src/lowgear/setup.rs
+++ b/offline-phase/src/lowgear/setup.rs
@@ -1,0 +1,31 @@
+//! Setup routines for the Lowgear implementation:
+//!     - Exchange BGV keys
+//!     - Generate MAC keys
+
+use ark_ec::CurveGroup;
+use ark_mpc::network::MpcNetwork;
+use mp_spdz_rs::fhe::plaintext::Plaintext;
+
+use crate::{error::LowGearError, lowgear::LowGear};
+
+impl<C: CurveGroup, N: MpcNetwork<C> + Unpin> LowGear<C, N> {
+    /// Exchange BGV public keys and mac shares with the counterparty
+    pub async fn run_key_exchange(&mut self) -> Result<(), LowGearError> {
+        // First, share the public key
+        self.send_message(self.local_keypair.public_key()).await?;
+        let counterparty_pk = self.receive_message().await?;
+
+        // Encrypt my mac share under my public key
+        let mut pt = Plaintext::new(&self.params);
+        pt.set_all(self.mac_share);
+        let ct = self.local_keypair.encrypt(&pt);
+
+        // Send and receive
+        self.send_message(ct).await?;
+        let counterparty_mac_enc = self.receive_message().await?;
+
+        self.other_pk = Some(counterparty_pk);
+        self.other_mac_enc = Some(counterparty_mac_enc);
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Purpose
This PR sets up the `LowGear` protocol in the offline phase. This involves generating BGV keypairs and MAC keys, then sharing the BGV public key and the encryption of the MAC key share with the counterparty over the network.

I also changed the build script in `mp-spdz-rs` to statically link all its dependent libraries. 

### Todo
- Testing for protocol setup
- Proof of plaintext knowledge for encrypted mac keys

### Testing
- Unit tests pass
- Tested the basic communication helpers for the `LowGear` protocol container struct