### PR TITLE
offline-phase: setup: Add protocol setup test

### DIFF
--- a/online-phase/benches/growable_buffer.rs
+++ b/online-phase/benches/growable_buffer.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unit_arg)]
+
 use ark_mpc::{algebra::Scalar, test_helpers::TestCurve, GrowableBuffer};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use rand::{seq::SliceRandom, thread_rng};

--- a/online-phase/src/algebra/curve/curve.rs
+++ b/online-phase/src/algebra/curve/curve.rs
@@ -23,10 +23,7 @@ use itertools::Itertools;
 use serde::{de::Error as DeError, Deserialize, Serialize};
 
 use crate::{
-    algebra::{
-        macros::*, n_bytes_field, scalar::*, ToBytes, AUTHENTICATED_POINT_RESULT_LEN,
-        AUTHENTICATED_SCALAR_RESULT_LEN,
-    },
+    algebra::{macros::*, scalar::*, ToBytes, AUTHENTICATED_POINT_RESULT_LEN},
     fabric::{ResultHandle, ResultValue},
 };
 


### PR DESCRIPTION
### Purpose
This PR adds a test for the protocol setup phase wherein each party sends an encryption of a known value and a homomorphically evaluated encryption of the counterparty's MAC key multiplied with a known public value. Both parties check their results are decryptable and as expected.

### Testing
- All unit tests pass