### PR TITLE
mp-spdz-rs: ffi, fhe: Add clone and serde methods for `CiphertextPoK`

### DIFF
--- a/mp-spdz-rs/src/ffi.rs
+++ b/mp-spdz-rs/src/ffi.rs
@@ -128,6 +128,9 @@ mod ffi_inner {
 
         // `CiphertextWithProof`
         type CiphertextWithProof;
+        fn clone(self: &CiphertextWithProof) -> UniquePtr<CiphertextWithProof>;
+        fn to_rust_bytes(self: &CiphertextWithProof) -> Vec<u8>;
+        fn ciphertext_with_proof_from_rust_bytes(data: &[u8]) -> UniquePtr<CiphertextWithProof>;
         fn encrypt_and_prove_batch(
             pk: &FHE_PK,
             plaintexts: Pin<&mut PlaintextVector>,

--- a/mp-spdz-rs/src/fhe/ciphertext.rs
+++ b/mp-spdz-rs/src/fhe/ciphertext.rs
@@ -160,6 +160,24 @@ pub struct CiphertextPoK<C: CurveGroup> {
     _phantom: PhantomData<C>,
 }
 
+impl<C: CurveGroup> Clone for CiphertextPoK<C> {
+    fn clone(&self) -> Self {
+        self.as_ref().clone().into()
+    }
+}
+
+impl<C: CurveGroup> ToBytes for CiphertextPoK<C> {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.as_ref().to_rust_bytes()
+    }
+}
+
+impl<C: CurveGroup> FromBytesWithParams<C> for CiphertextPoK<C> {
+    fn from_bytes(data: &[u8], _: &BGVParams<C>) -> Self {
+        ffi::ciphertext_with_proof_from_rust_bytes(data).into()
+    }
+}
+
 impl<C: CurveGroup> From<UniquePtr<ffi::CiphertextWithProof>> for CiphertextPoK<C> {
     fn from(inner: UniquePtr<ffi::CiphertextWithProof>) -> Self {
         Self { inner, _phantom: PhantomData }


### PR DESCRIPTION
### Purpose
This PR adds serialization/deserialization and cloning to the `CiphertextPoK` struct. This is ahead of its integration into the setup and Beaver triplet authentication flows which require the `CiphertextPoK` to be sent over the network.

### Testing
- Unit tests pass