### PR TITLE
offline-phase: Prove & verify ciphertext PoK in key exchange

### DIFF
--- a/mp-spdz-rs/src/ffi.rs
+++ b/mp-spdz-rs/src/ffi.rs
@@ -150,6 +150,7 @@ unsafe impl Send for FHE_Params {}
 unsafe impl Send for FHE_KeyPair {}
 unsafe impl Send for FHE_PK {}
 unsafe impl Send for Ciphertext {}
+unsafe impl Send for CiphertextWithProof {}
 unsafe impl Send for Plaintext_mod_prime {}
 
 #[cfg(test)]


### PR DESCRIPTION
### Purpose
When the two parties setup a global MAC key they prove knowledge of the key to avoid adversarial waiting that may allow a party to induce algebraic structure on the key by choosing their key appropriately.

This PoK also asserts that the noise is within a given bound, i.e. that the ciphertext may be properly decrypted.

### Testing
- Unit tested proof verification within the context of key setup
- All unit tests pass