### PR TITLE
offline-phase: lowgear: triplets: Implement initial triplet gen phase

### DIFF
--- a/mp-spdz-rs/src/ffi.rs
+++ b/mp-spdz-rs/src/ffi.rs
@@ -87,10 +87,12 @@ mod ffi_inner {
 
         // `PlaintextVector`
         type PlaintextVector;
+        fn new_empty_plaintext_vector() -> UniquePtr<PlaintextVector>;
         fn new_plaintext_vector(size: usize, params: &FHE_Params) -> UniquePtr<PlaintextVector>;
         fn new_plaintext_vector_single(
             plaintext: &Plaintext_mod_prime,
         ) -> UniquePtr<PlaintextVector>;
+        fn random_plaintext_vector(size: usize, params: &FHE_Params) -> UniquePtr<PlaintextVector>;
         fn get_plaintext_vector_element(
             vector: &PlaintextVector,
             index: usize,
@@ -150,8 +152,10 @@ unsafe impl Send for FHE_Params {}
 unsafe impl Send for FHE_KeyPair {}
 unsafe impl Send for FHE_PK {}
 unsafe impl Send for Ciphertext {}
+unsafe impl Send for CiphertextVector {}
 unsafe impl Send for CiphertextWithProof {}
 unsafe impl Send for Plaintext_mod_prime {}
+unsafe impl Send for PlaintextVector {}
 
 #[cfg(test)]
 mod test {

--- a/mp-spdz-rs/src/fhe/params.rs
+++ b/mp-spdz-rs/src/fhe/params.rs
@@ -60,6 +60,11 @@ impl<C: CurveGroup> BGVParams<C> {
     pub fn plaintext_slots(&self) -> u32 {
         self.as_ref().n_plaintext_slots()
     }
+
+    /// Get the number of ciphertexts that may be proven together
+    pub fn ciphertext_pok_batch_size(&self) -> usize {
+        (self.plaintext_slots() as usize) * (DEFAULT_DROWN_SEC as usize)
+    }
 }
 
 impl<C: CurveGroup> Serialize for BGVParams<C> {

--- a/offline-phase/src/lowgear/mod.rs
+++ b/offline-phase/src/lowgear/mod.rs
@@ -2,6 +2,7 @@
 //! keys, authenticating inputs, etc
 
 pub mod setup;
+pub mod triplets;
 
 use ark_ec::CurveGroup;
 use ark_mpc::{

--- a/offline-phase/src/lowgear/triplets.rs
+++ b/offline-phase/src/lowgear/triplets.rs
@@ -1,0 +1,50 @@
+//! Defines the logic for generating shared triples (a, b, c) which satisfy the
+//! identity:
+//!      a * b = c
+//!
+//! These triples are used to define single-round multiplication in the SPDZ
+//! protocol
+
+use ark_ec::CurveGroup;
+use ark_mpc::network::MpcNetwork;
+use mp_spdz_rs::fhe::{ciphertext::CiphertextPoK, plaintext::PlaintextVector};
+
+use crate::error::LowGearError;
+
+use super::LowGear;
+
+impl<C: CurveGroup, N: MpcNetwork<C> + Unpin> LowGear<C, N> {
+    /// Generate a single batch of shared triples
+    pub async fn generate_triples(&mut self) -> Result<(), LowGearError> {
+        // First step; generate random values a and b
+        let mut a = PlaintextVector::random_pok_batch(&self.params);
+        let b = PlaintextVector::random_pok_batch(&self.params);
+
+        // Compute a plaintext multiplication
+        let c = &a * &b;
+
+        // Encrypt `a` and send it to the counterparty
+        let my_proof = self.local_keypair.encrypt_and_prove_vector(&mut a);
+        self.send_message(my_proof).await?;
+        let mut other_proof: CiphertextPoK<C> = self.receive_message().await?;
+
+        let other_pk = self.other_pk.as_ref().expect("setup not run");
+        let other_a_enc = other_pk.verify_proof(&mut other_proof);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::test_helpers::mock_lowgear_with_keys;
+
+    /// Tests the basic triplet generation flow
+    #[tokio::test]
+    async fn test_triplet_gen() {
+        mock_lowgear_with_keys(|mut lowgear| async move {
+            lowgear.generate_triples().await.unwrap();
+        })
+        .await;
+    }
+}


### PR DESCRIPTION
### Purpose
This PR implements the first phase of triplet generation. This involves each party generating local shares of the triplet, encrypting their `a` value, generating a ciphertext PoK, and sending it to the counterparty.

The counterparty then verifies the PoK.

### Testing
- Created a test for triplet generation, it passes
- Unit tests pass broadly