### PR TITLE
offline-phase: lowgear: shared-random: Generate shared random values

### DIFF
--- a/mp-spdz-rs/src/fhe/params.rs
+++ b/mp-spdz-rs/src/fhe/params.rs
@@ -57,13 +57,13 @@ impl<C: CurveGroup> BGVParams<C> {
     }
 
     /// Get the number of plaintext slots the given parameters support
-    pub fn plaintext_slots(&self) -> u32 {
-        self.as_ref().n_plaintext_slots()
+    pub fn plaintext_slots(&self) -> usize {
+        self.as_ref().n_plaintext_slots() as usize
     }
 
     /// Get the number of ciphertexts that may be proven together
     pub fn ciphertext_pok_batch_size(&self) -> usize {
-        (self.plaintext_slots() as usize) * (DEFAULT_DROWN_SEC as usize)
+        self.plaintext_slots() * (DEFAULT_DROWN_SEC as usize)
     }
 }
 

--- a/offline-phase/src/lowgear/inverse_tuples.rs
+++ b/offline-phase/src/lowgear/inverse_tuples.rs
@@ -1,0 +1,23 @@
+//! Defines the subprotocol for generating tuples (a, a^{-1}) for a random value
+//! a
+
+use ark_ec::CurveGroup;
+use ark_mpc::network::MpcNetwork;
+
+use crate::error::LowGearError;
+
+use super::LowGear;
+
+impl<C: CurveGroup, N: MpcNetwork<C> + Unpin + Send> LowGear<C, N> {
+    /// Generate a set of inverse tuples
+    pub async fn generate_inverse_tuples(&mut self, n: usize) -> Result<(), LowGearError> {
+        // We use one triplet per tuple, so we need at least n triples
+        assert!(self.triples.len() >= n, "not enough triplets for {n} inverse tuples");
+        let random_values = self.get_authenticated_randomness_vec(2 * n).await?;
+
+        // Split into halves that we will multiply using the Beaver trick
+        let (random_values1, random_values2) = random_values.split_at(n);
+
+        Ok(())
+    }
+}

--- a/offline-phase/src/lowgear/mod.rs
+++ b/offline-phase/src/lowgear/mod.rs
@@ -2,7 +2,9 @@
 //! keys, authenticating inputs, etc
 
 pub mod commit_reveal;
+pub mod inverse_tuples;
 pub mod mac_check;
+pub mod multiplication;
 pub mod setup;
 pub mod shared_random;
 pub mod triplets;
@@ -43,6 +45,8 @@ pub struct LowGear<C: CurveGroup, N: MpcNetwork<C>> {
     pub other_mac_enc: Option<Ciphertext<C>>,
     /// The Beaver triples generated during the offline phase
     pub triples: Vec<(ValueMac<C>, ValueMac<C>, ValueMac<C>)>,
+    /// The inverse tuples generated during the offline phase
+    pub inverse_tuples: Vec<(ValueMac<C>, ValueMac<C>)>,
     /// A reference to the underlying network connection
     pub network: N,
 }
@@ -63,6 +67,7 @@ impl<C: CurveGroup, N: MpcNetwork<C> + Unpin> LowGear<C, N> {
             other_pk: None,
             other_mac_enc: None,
             triples: Default::default(),
+            inverse_tuples: Default::default(),
             network,
         }
     }

--- a/offline-phase/src/lowgear/multiplication.rs
+++ b/offline-phase/src/lowgear/multiplication.rs
@@ -1,0 +1,1 @@
+//! Multiplication sub-protocol using the Beaver trick

--- a/offline-phase/src/lowgear/triplets.rs
+++ b/offline-phase/src/lowgear/triplets.rs
@@ -100,7 +100,7 @@ impl<C: CurveGroup, N: MpcNetwork<C> + Unpin> LowGear<C, N> {
     }
 
     /// Authenticate a plaintext vector with the counterparty
-    async fn authenticate_vec(
+    pub async fn authenticate_vec(
         &mut self,
         a: &PlaintextVector<C>,
     ) -> Result<PlaintextVector<C>, LowGearError> {
@@ -416,7 +416,7 @@ mod test {
         // The number of plaintext vectors to test
         mock_lowgear_with_keys(|mut lowgear| async move {
             // Generate values for the triplets
-            let n_slots = lowgear.params.plaintext_slots() as usize;
+            let n_slots = lowgear.params.plaintext_slots();
             let my_a = random_scalars(n_slots);
             let my_b = random_scalars(n_slots);
             let my_c = random_scalars(n_slots);


### PR DESCRIPTION
### Purpose
This PR adds a subprotocol to generate shared random values in the offline phase. We will combine shared, authenticated random values to create shared inverse tuples and shared bits.

### Testing
- Unit tests pass
- Tested the shared randomness subprotocol, specifically that the MACs are correctly constructed