### PR TITLE
offline-phase: lowgear: shared_bits: Implement shared bits generation

### DIFF
--- a/offline-phase/src/lowgear/mod.rs
+++ b/offline-phase/src/lowgear/mod.rs
@@ -6,6 +6,7 @@ pub mod inverse_tuples;
 pub mod mac_check;
 pub mod multiplication;
 pub mod setup;
+pub mod shared_bits;
 pub mod shared_random;
 pub mod triplets;
 
@@ -47,6 +48,8 @@ pub struct LowGear<C: CurveGroup, N: MpcNetwork<C>> {
     pub triples: Vec<(ValueMac<C>, ValueMac<C>, ValueMac<C>)>,
     /// The inverse tuples generated during the offline phase
     pub inverse_tuples: Vec<(ValueMac<C>, ValueMac<C>)>,
+    /// The shared bits generated during the offline phase
+    pub shared_bits: Vec<ValueMac<C>>,
     /// A reference to the underlying network connection
     pub network: N,
 }
@@ -68,6 +71,7 @@ impl<C: CurveGroup, N: MpcNetwork<C> + Unpin> LowGear<C, N> {
             other_mac_enc: None,
             triples: Default::default(),
             inverse_tuples: Default::default(),
+            shared_bits: Default::default(),
             network,
         }
     }

--- a/offline-phase/src/lowgear/shared_bits.rs
+++ b/offline-phase/src/lowgear/shared_bits.rs
@@ -1,0 +1,66 @@
+//! Subprotocol to generate secret shares of bits, i.e. Scalars in {0, 1}
+
+use ark_ec::CurveGroup;
+use ark_mpc::{algebra::Scalar, network::MpcNetwork};
+use itertools::Itertools;
+
+use crate::error::LowGearError;
+
+use super::LowGear;
+
+impl<C: CurveGroup, N: MpcNetwork<C> + Unpin + Send> LowGear<C, N> {
+    /// Generate shared bits
+    ///
+    /// This works as follows:
+    /// 1. Generate random shared values and square them via the multiplication
+    ///    subprotocol
+    /// 2. Open the squared values
+    /// 3. Take the square root of the opened values, invert it, then multiply
+    ///    with the original shared random value
+    /// 4. This is either -1 or 1 with equal probability due to QR
+    /// 5. Shift this range to 0, 1; i.e. add one, divide by two
+    pub async fn generate_shared_bits(&mut self, n: usize) -> Result<(), LowGearError> {
+        // This method requires `n` tuples to sacrifice in the multiplication step
+        assert!(self.triples.len() >= n, "Not enough triples to generate {} bits", n);
+        let random_vals = self.get_authenticated_randomness_vec(n).await?;
+        let squared_vals = self.beaver_mul(&random_vals, &random_vals).await?;
+
+        // Open the squared values, take the square root, invert, and multiply with the
+        // original random value
+        let opened_vals = self.open_and_check_macs(&squared_vals).await?;
+        let sqrt_inv_vals = opened_vals.iter().map(|x| x.sqrt().unwrap().inverse()).collect_vec();
+
+        // Multiply with the original random value and shift the resulting range
+        let ones = (0..n).map(|_| Scalar::one()).collect_vec();
+        let inv_twos = (0..n).map(|_| Scalar::from(2u8).inverse()).collect_vec();
+
+        let mut neg_one_or_one = &random_vals * sqrt_inv_vals.as_slice();
+        self.add_public_value(&ones, &mut neg_one_or_one);
+        let bits = &neg_one_or_one * inv_twos.as_slice();
+        self.shared_bits = bits.into_inner();
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ark_mpc::algebra::Scalar;
+
+    use crate::{beaver_source::ValueMacBatch, test_helpers::mock_lowgear_with_triples};
+
+    /// Tests the `generate_shared_bits` method
+    #[tokio::test]
+    async fn test_generate_shared_bits() {
+        const N: usize = 1000;
+        mock_lowgear_with_triples(N, |mut lowgear| async move {
+            lowgear.generate_shared_bits(N).await.unwrap();
+
+            // Open the shared bits and check that they are either 0 or 1
+            let bits = ValueMacBatch::new(lowgear.shared_bits.clone());
+            let opened_bits = lowgear.open_and_check_macs(&bits).await.unwrap();
+            assert!(opened_bits.iter().all(|x| *x == Scalar::zero() || *x == Scalar::one()));
+        })
+        .await;
+    }
+}

--- a/online-phase/src/algebra/scalar/scalar.rs
+++ b/online-phase/src/algebra/scalar/scalar.rs
@@ -83,6 +83,11 @@ impl<C: CurveGroup> Scalar<C> {
         Scalar(self.0.inverse().unwrap())
     }
 
+    /// Compute the square root of the given scalar
+    pub fn sqrt(&self) -> Option<Self> {
+        self.0.sqrt().map(Scalar)
+    }
+
     /// Compute the batch inversion of a list of Scalars
     pub fn batch_inverse(vals: &mut [Self]) {
         let mut values = vals.iter().map(|x| x.0).collect_vec();


### PR DESCRIPTION
### Purpose
This PR generates shared bits in the offline phase by consuming Beaver triplets. This is done by squaring a random value, opening it, inverting the opened value, then multiplying with the original random value. This gives a value in $\{-1, 1\}$ which can then be shifted using public operations into $\{0, 1\}$.

### Testing
- Unit tests pass
- Tested the shared bits method, verified that the macs are correctly computed and the resulting values are in $\{0, 1\}$.