### PR TITLE
offline-phase: lowgear: structs: Define offline phase result

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 `ark-mpc` provides a malicious secure [SPDZ](https://eprint.iacr.org/2011/535.pdf) style framework for two party secure computation. The circuit is constructed on the fly, by overloading arithmetic operators of MPC types, see the example below in which each of the parties shares a value and together they compute the product:
 ```rust
 use ark_mpc::{
-    algebra::scalar::Scalar, beaver::SharedValueSource, network::QuicTwoPartyNet, MpcFabric,
+    algebra::scalar::Scalar, beaver::OfflinePhase, network::QuicTwoPartyNet, MpcFabric,
     PARTY0, PARTY1,
 };
 use ark_curve25519::EdwardsProjective as Curve25519Projective;

--- a/mp-spdz-rs/src/ffi.rs
+++ b/mp-spdz-rs/src/ffi.rs
@@ -1,5 +1,6 @@
 //! The FFI bindings for the MP-SPDZ library
 
+#[allow(unused)]
 #[allow(clippy::missing_safety_doc)]
 #[allow(clippy::missing_docs_in_private_items)]
 #[allow(missing_docs)]

--- a/offline-phase/src/lib.rs
+++ b/offline-phase/src/lib.rs
@@ -14,9 +14,9 @@
 #![feature(inherent_associated_types)]
 #![feature(stmt_expr_attributes)]
 
-pub mod beaver_source;
 pub mod error;
 pub mod lowgear;
+pub mod structs;
 
 #[cfg(test)]
 pub(crate) mod test_helpers {
@@ -27,7 +27,7 @@ pub(crate) mod test_helpers {
         PARTY0, PARTY1,
     };
     use futures::Future;
-    use itertools::{izip, Itertools};
+    use itertools::Itertools;
     use mp_spdz_rs::fhe::{
         ciphertext::Ciphertext,
         keys::{BGVKeypair, BGVPublicKey},
@@ -36,7 +36,7 @@ pub(crate) mod test_helpers {
     };
     use rand::thread_rng;
 
-    use crate::{beaver_source::ValueMacBatch, lowgear::LowGear};
+    use crate::{lowgear::LowGear, structs::ValueMacBatch};
 
     /// The curve used for testing in this crate
     pub type TestCurve = ark_bn254::G1Projective;
@@ -172,8 +172,8 @@ pub(crate) mod test_helpers {
         let (b1, b2) = generate_authenticated_secret_shares(&b, mac_key);
         let (c1, c2) = generate_authenticated_secret_shares(&c, mac_key);
 
-        lowgear1.triples = izip!(a1, b1, c1).collect_vec();
-        lowgear2.triples = izip!(a2, b2, c2).collect_vec();
+        lowgear1.triples = (a1, b1, c1);
+        lowgear2.triples = (a2, b2, c2);
 
         run_mock_lowgear(f, lowgear1, lowgear2).await
     }

--- a/offline-phase/src/lowgear/mac_check.rs
+++ b/offline-phase/src/lowgear/mac_check.rs
@@ -3,7 +3,7 @@
 use ark_ec::CurveGroup;
 use ark_mpc::{algebra::Scalar, network::MpcNetwork};
 
-use crate::{beaver_source::ValueMacBatch, error::LowGearError};
+use crate::{error::LowGearError, structs::ValueMacBatch};
 
 use super::LowGear;
 

--- a/offline-phase/src/lowgear/shared_random.rs
+++ b/offline-phase/src/lowgear/shared_random.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use mp_spdz_rs::fhe::plaintext::PlaintextVector;
 use rand::rngs::OsRng;
 
-use crate::{beaver_source::ValueMacBatch, error::LowGearError};
+use crate::{error::LowGearError, structs::ValueMacBatch};
 
 use super::LowGear;
 

--- a/online-phase/benches/gate_throughput.rs
+++ b/online-phase/benches/gate_throughput.rs
@@ -1,8 +1,8 @@
 use std::{path::Path, sync::Mutex};
 
 use ark_mpc::{
-    algebra::Scalar, beaver::PartyIDBeaverSource, network::NoRecvNetwork, test_helpers::TestCurve,
-    ExecutorSizeHints, MpcFabric, PARTY0,
+    algebra::Scalar, network::NoRecvNetwork, offline_prep::PartyIDBeaverSource,
+    test_helpers::TestCurve, ExecutorSizeHints, MpcFabric, PARTY0,
 };
 use cpuprofiler::{Profiler as CpuProfiler, PROFILER};
 use criterion::{

--- a/online-phase/benches/gate_throughput_traced.rs
+++ b/online-phase/benches/gate_throughput_traced.rs
@@ -4,8 +4,8 @@
 use std::time::Instant;
 
 use ark_mpc::{
-    algebra::Scalar, beaver::PartyIDBeaverSource, network::NoRecvNetwork, test_helpers::TestCurve,
-    ExecutorSizeHints, MpcFabric, PARTY0,
+    algebra::Scalar, network::NoRecvNetwork, offline_prep::PartyIDBeaverSource,
+    test_helpers::TestCurve, ExecutorSizeHints, MpcFabric, PARTY0,
 };
 use clap::Parser;
 use cpuprofiler::PROFILER;

--- a/online-phase/integration/helpers.rs
+++ b/online-phase/integration/helpers.rs
@@ -7,8 +7,8 @@ use ark_mpc::{
         AuthenticatedPointResult, AuthenticatedScalarResult, MpcPointResult, MpcScalarResult,
         Scalar,
     },
-    beaver::SharedValueSource,
     network::{NetworkPayload, PartyId},
+    offline_prep::OfflinePhase,
     {MpcFabric, ResultHandle, ResultValue},
 };
 use futures::{future::join_all, Future};
@@ -237,7 +237,7 @@ impl PartyIDBeaverSource {
 /// The PartyIDBeaverSource returns beaver triplets split statically between the
 /// parties. We assume a = 2, b = 3 ==> c = 6. [a] = (1, 1); [b] = (3, 0) [c] =
 /// (2, 4)
-impl SharedValueSource<TestCurve> for PartyIDBeaverSource {
+impl OfflinePhase<TestCurve> for PartyIDBeaverSource {
     fn next_shared_bit(&mut self) -> TestScalar {
         // Simply output partyID, assume partyID \in {0, 1}
         assert!(self.party_id == 0 || self.party_id == 1);

--- a/online-phase/src/fabric.rs
+++ b/online-phase/src/fabric.rs
@@ -41,8 +41,8 @@ use crate::{
         BatchScalarResult, CurvePoint, CurvePointResult, MpcPointResult, MpcScalarResult, Scalar,
         ScalarResult,
     },
-    beaver::SharedValueSource,
     network::{MpcNetwork, NetworkOutbound, NetworkPayload, PartyId},
+    offline_prep::OfflinePhase,
     PARTY0,
 };
 
@@ -203,7 +203,7 @@ pub struct FabricInner<C: CurveGroup> {
     /// The underlying queue to the network
     outbound_queue: KanalSender<NetworkOutbound<C>>,
     /// The underlying shared randomness source
-    beaver_source: Arc<Mutex<Box<dyn SharedValueSource<C>>>>,
+    beaver_source: Arc<Mutex<Box<dyn OfflinePhase<C>>>>,
 }
 
 impl<C: CurveGroup> Debug for FabricInner<C> {
@@ -214,7 +214,7 @@ impl<C: CurveGroup> Debug for FabricInner<C> {
 
 impl<C: CurveGroup> FabricInner<C> {
     /// Constructor
-    pub fn new<S: 'static + SharedValueSource<C>>(
+    pub fn new<S: 'static + OfflinePhase<C>>(
         party_id: u64,
         execution_queue: ExecutorJobQueue<C>,
         outbound_queue: KanalSender<NetworkOutbound<C>>,
@@ -388,7 +388,7 @@ impl<C: CurveGroup> FabricInner<C> {
 
 impl<C: CurveGroup> MpcFabric<C> {
     /// Constructor
-    pub fn new<N: 'static + MpcNetwork<C>, S: 'static + SharedValueSource<C>>(
+    pub fn new<N: 'static + MpcNetwork<C>, S: 'static + OfflinePhase<C>>(
         network: N,
         beaver_source: S,
     ) -> Self {
@@ -398,7 +398,7 @@ impl<C: CurveGroup> MpcFabric<C> {
     /// Constructor that takes an additional size hint, indicating how much
     /// buffer space the fabric should allocate for results. The size is
     /// given in number of gates
-    pub fn new_with_size_hint<N: 'static + MpcNetwork<C>, S: 'static + SharedValueSource<C>>(
+    pub fn new_with_size_hint<N: 'static + MpcNetwork<C>, S: 'static + OfflinePhase<C>>(
         size_hints: ExecutorSizeHints,
         network: N,
         beaver_source: S,
@@ -421,7 +421,7 @@ impl<C: CurveGroup> MpcFabric<C> {
 
     /// Constructor that takes an additional size hint as well as a queue for
     /// the executor
-    pub fn new_with_executor<N: 'static + MpcNetwork<C>, S: 'static + SharedValueSource<C>>(
+    pub fn new_with_executor<N: 'static + MpcNetwork<C>, S: 'static + OfflinePhase<C>>(
         network: N,
         beaver_source: S,
         executor_queue: ExecutorJobQueue<C>,

--- a/online-phase/src/lib.rs
+++ b/online-phase/src/lib.rs
@@ -15,11 +15,11 @@ use ark_ec::CurveGroup;
 use rand::thread_rng;
 
 pub mod algebra;
-pub mod beaver;
 pub mod commitment;
 pub mod error;
 pub(crate) mod fabric;
 pub mod gadgets;
+pub mod offline_prep;
 #[cfg(feature = "benchmarks")]
 pub use fabric::*;
 #[cfg(not(feature = "benchmarks"))]
@@ -53,9 +53,9 @@ pub mod test_helpers {
     use futures::Future;
 
     use crate::{
-        beaver::{PartyIDBeaverSource, SharedValueSource},
         fabric::ExecutorSizeHints,
         network::{MockNetwork, NoRecvNetwork, UnboundedDuplexStream},
+        offline_prep::{OfflinePhase, PartyIDBeaverSource},
         MpcFabric, PARTY0, PARTY1,
     };
 
@@ -124,7 +124,7 @@ pub mod test_helpers {
         party1_beaver: B,
     ) -> (T, T)
     where
-        B: 'static + SharedValueSource<TestCurve>,
+        B: 'static + OfflinePhase<TestCurve>,
         T: Send + 'static,
         S: Future<Output = T> + Send + 'static,
         F: FnMut(MpcFabric<TestCurve>) -> S,

--- a/online-phase/src/offline_prep.rs
+++ b/online-phase/src/offline_prep.rs
@@ -6,12 +6,12 @@ use itertools::Itertools;
 
 use crate::{algebra::Scalar, network::PartyId};
 
-/// SharedValueSource implements both the functionality for:
+/// OfflinePhase implements both the functionality for:
 ///     1. Single additively shared values [x] where party 1 holds x_1 and party
 ///        2 holds x_2 such that x_1 + x_2 = x
 ///     2. Beaver triplets; additively shared values [a], [b], [c] such that a *
 ///        b = c
-pub trait SharedValueSource<C: CurveGroup>: Send + Sync {
+pub trait OfflinePhase<C: CurveGroup>: Send + Sync {
     /// Fetch the next shared single bit
     fn next_shared_bit(&mut self) -> Scalar<C>;
     /// Fetch the next shared batch of bits
@@ -77,7 +77,7 @@ impl PartyIDBeaverSource {
 /// parties. We assume a = 2, b = 3 ==> c = 6. [a] = (1, 1); [b] = (3, 0) [c] =
 /// (2, 4)
 #[cfg(any(feature = "test_helpers", test))]
-impl<C: CurveGroup> SharedValueSource<C> for PartyIDBeaverSource {
+impl<C: CurveGroup> OfflinePhase<C> for PartyIDBeaverSource {
     fn next_shared_bit(&mut self) -> Scalar<C> {
         // Simply output partyID, assume partyID \in {0, 1}
         assert!(self.party_id == 0 || self.party_id == 1);
@@ -117,7 +117,7 @@ impl ZeroBeaverSource {
 }
 
 #[cfg(any(feature = "test_helpers", test))]
-impl<C: CurveGroup> SharedValueSource<C> for ZeroBeaverSource {
+impl<C: CurveGroup> OfflinePhase<C> for ZeroBeaverSource {
     fn next_shared_bit(&mut self) -> Scalar<C> {
         Scalar::zero()
     }


### PR DESCRIPTION
### Purpose
This PR defines the types that result from running the `LowGear` offline phase. This structure stores the inverse tuples, shared bits, and Beaver triplets that the `LowGear` protocol generates. We will use this struct to implement `OfflinePhase` and integrate with the online phase.

### Testing
- Unit tests pass