### PR TITLE
offline-phase: lowgear: shared-random: Generate authenticated, shared…

### DIFF
--- a/offline-phase/src/lowgear/mod.rs
+++ b/offline-phase/src/lowgear/mod.rs
@@ -50,6 +50,8 @@ pub struct LowGear<C: CurveGroup, N: MpcNetwork<C>> {
     pub inverse_tuples: (ValueMacBatch<C>, ValueMacBatch<C>),
     /// The shared bits generated during the offline phase
     pub shared_bits: ValueMacBatch<C>,
+    /// The shared random values generated during the offline phase
+    pub shared_randomness: ValueMacBatch<C>,
     /// A reference to the underlying network connection
     pub network: N,
 }
@@ -72,6 +74,7 @@ impl<C: CurveGroup, N: MpcNetwork<C> + Unpin> LowGear<C, N> {
             triples: Default::default(),
             inverse_tuples: Default::default(),
             shared_bits: Default::default(),
+            shared_randomness: Default::default(),
             network,
         }
     }
@@ -98,12 +101,14 @@ impl<C: CurveGroup, N: MpcNetwork<C> + Unpin> LowGear<C, N> {
     }
 
     /// Get the prep result from the LowGear
-    pub fn get_offline_result(&mut self) -> LowGearPrep<C> {
-        LowGearPrep::new(
+    pub fn get_offline_result(&mut self) -> Result<LowGearPrep<C>, LowGearError> {
+        Ok(LowGearPrep::new(
+            self.get_setup_params()?,
             self.inverse_tuples.clone(),
             self.shared_bits.clone(),
+            self.shared_randomness.clone(),
             self.triples.clone(),
-        )
+        ))
     }
 
     /// Get a plaintext with the local mac share in all slots

--- a/offline-phase/src/lowgear/shared_random.rs
+++ b/offline-phase/src/lowgear/shared_random.rs
@@ -11,6 +11,14 @@ use crate::{error::LowGearError, structs::ValueMacBatch};
 use super::LowGear;
 
 impl<C: CurveGroup, N: MpcNetwork<C> + Unpin + Send> LowGear<C, N> {
+    /// Generate shared randomness to store in the offline phase result
+    pub async fn generate_shared_randomness(&mut self, n: usize) -> Result<(), LowGearError> {
+        let random_vals = self.get_authenticated_randomness_vec(n).await?;
+        self.shared_randomness = random_vals;
+
+        Ok(())
+    }
+
     /// Generate a single shared random value via commit/reveal
     pub async fn get_shared_randomness(&mut self) -> Result<Scalar<C>, LowGearError> {
         Ok(self.get_shared_randomness_vec(1).await?[0])

--- a/offline-phase/src/structs.rs
+++ b/offline-phase/src/structs.rs
@@ -31,10 +31,14 @@ pub struct LowGearParams<C: CurveGroup> {
 /// The resulting shared values created by the lowgear offline phase
 #[derive(Clone)]
 pub struct LowGearPrep<C: CurveGroup> {
+    /// The params in the lowgear instance
+    pub params: LowGearParams<C>,
     /// The shared inverse pairs
     pub inverse_pairs: (ValueMacBatch<C>, ValueMacBatch<C>),
     /// The shared bits
     pub bits: ValueMacBatch<C>,
+    /// The shared random values
+    pub shared_randomness: ValueMacBatch<C>,
     /// The shared Beaver triplets
     pub triplets: (ValueMacBatch<C>, ValueMacBatch<C>, ValueMacBatch<C>),
 }
@@ -42,18 +46,22 @@ pub struct LowGearPrep<C: CurveGroup> {
 impl<C: CurveGroup> LowGearPrep<C> {
     /// Create a new `LowGearPrep`
     pub fn new(
+        params: LowGearParams<C>,
         inverse_pairs: (ValueMacBatch<C>, ValueMacBatch<C>),
         bits: ValueMacBatch<C>,
+        shared_randomness: ValueMacBatch<C>,
         triplets: (ValueMacBatch<C>, ValueMacBatch<C>, ValueMacBatch<C>),
     ) -> Self {
-        Self { inverse_pairs, bits, triplets }
+        Self { params, inverse_pairs, bits, shared_randomness, triplets }
     }
 
     /// Create an empty `LowGearPrep`
-    pub fn empty() -> Self {
+    pub fn empty(params: LowGearParams<C>) -> Self {
         Self {
+            params,
             inverse_pairs: (ValueMacBatch::new(vec![]), ValueMacBatch::new(vec![])),
             bits: ValueMacBatch::new(vec![]),
+            shared_randomness: ValueMacBatch::new(vec![]),
             triplets: (
                 ValueMacBatch::new(vec![]),
                 ValueMacBatch::new(vec![]),


### PR DESCRIPTION
### Purpose
This PR adds logic to generate shared, authenticated random values in the offline phase. This completes the data needed to satisfy the `OfflinePhase` trait used in the online phase.

### Testing
- Unit tests pass 