### PR TITLE
offline-phase: structs: Implement `OfflinePhase` for `LowGearPrep`

### DIFF
--- a/mp-spdz-rs/src/ffi.rs
+++ b/mp-spdz-rs/src/ffi.rs
@@ -168,7 +168,9 @@ mod ffi_inner {
 }
 pub use ffi_inner::*;
 unsafe impl Send for FHE_Params {}
+unsafe impl Sync for FHE_Params {}
 unsafe impl Send for FHE_KeyPair {}
+unsafe impl Sync for FHE_KeyPair {}
 unsafe impl Send for FHE_PK {}
 unsafe impl Sync for FHE_PK {}
 unsafe impl Send for Ciphertext {}

--- a/offline-phase/src/lib.rs
+++ b/offline-phase/src/lib.rs
@@ -87,7 +87,7 @@ pub(crate) mod test_helpers {
         let mut rng = thread_rng();
         let a = (0..n).map(|_| Scalar::<TestCurve>::random(&mut rng)).collect_vec();
         let b = (0..n).map(|_| Scalar::<TestCurve>::random(&mut rng)).collect_vec();
-        let c = (0..n).map(|_| Scalar::<TestCurve>::random(&mut rng)).collect_vec();
+        let c = a.iter().zip(b.iter()).map(|(a, b)| a * b).collect_vec();
 
         (a, b, c)
     }

--- a/online-phase/src/offline_prep.rs
+++ b/online-phase/src/offline_prep.rs
@@ -56,6 +56,7 @@ pub trait OfflinePhase<C: CurveGroup>: Send + Sync {
         (a_vals, b_vals, c_vals)
     }
 }
+
 /// An implementation of a beaver value source that returns
 /// beaver triples (0, 0, 0) for party 0 and (1, 1, 1) for party 1
 #[cfg(any(feature = "test_helpers", test))]


### PR DESCRIPTION
### Purpose
This PR implement `OfflinePhase` for `LowGearPrep`; the interface used by the online phase to interact with the result of the offline phase. I also added a test to ensure that this link works by running an MPC on the result of the lowgear protocol.

### Todo
- Input authentication using the params setup in the offline phase

### Testing
- Unit tests pass