### PR TITLE
online-phase: fabric: Authenticate inputs with input masks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 `ark-mpc` provides a malicious secure [SPDZ](https://eprint.iacr.org/2011/535.pdf) style framework for two party secure computation. The circuit is constructed on the fly, by overloading arithmetic operators of MPC types, see the example below in which each of the parties shares a value and together they compute the product:
 ```rust
 use ark_mpc::{
-    algebra::scalar::Scalar, beaver::OfflinePhase, network::QuicTwoPartyNet, MpcFabric,
+    algebra::scalar::Scalar, beaver::PreprocessingPhase, network::QuicTwoPartyNet, MpcFabric,
     PARTY0, PARTY1,
 };
 use ark_curve25519::EdwardsProjective as Curve25519Projective;

--- a/online-phase/src/fabric/result.rs
+++ b/online-phase/src/fabric/result.rs
@@ -118,6 +118,11 @@ impl<C: CurveGroup> From<ResultValue<C>> for Vec<u8> {
         }
     }
 }
+impl<C: CurveGroup> From<Vec<u8>> for ResultValue<C> {
+    fn from(value: Vec<u8>) -> Self {
+        ResultValue::Bytes(value)
+    }
+}
 
 impl<C: CurveGroup> From<ResultValue<C>> for Scalar<C> {
     fn from(value: ResultValue<C>) -> Self {
@@ -125,6 +130,12 @@ impl<C: CurveGroup> From<ResultValue<C>> for Scalar<C> {
             ResultValue::Scalar(scalar) => scalar,
             _ => panic!("Cannot cast {:?} to scalar", value),
         }
+    }
+}
+
+impl<C: CurveGroup> From<Scalar<C>> for ResultValue<C> {
+    fn from(value: Scalar<C>) -> Self {
+        ResultValue::Scalar(value)
     }
 }
 
@@ -146,6 +157,12 @@ impl<C: CurveGroup> From<ResultValue<C>> for Vec<Scalar<C>> {
     }
 }
 
+impl<C: CurveGroup> From<Vec<Scalar<C>>> for ResultValue<C> {
+    fn from(value: Vec<Scalar<C>>) -> Self {
+        ResultValue::ScalarBatch(value)
+    }
+}
+
 impl<C: CurveGroup> From<ResultValue<C>> for ScalarShare<C> {
     fn from(value: ResultValue<C>) -> Self {
         match value {
@@ -155,12 +172,24 @@ impl<C: CurveGroup> From<ResultValue<C>> for ScalarShare<C> {
     }
 }
 
+impl<C: CurveGroup> From<ScalarShare<C>> for ResultValue<C> {
+    fn from(value: ScalarShare<C>) -> Self {
+        ResultValue::ScalarShare(value)
+    }
+}
+
 impl<C: CurveGroup> From<ResultValue<C>> for CurvePoint<C> {
     fn from(value: ResultValue<C>) -> Self {
         match value {
             ResultValue::Point(point) => point,
             _ => panic!("Cannot cast {:?} to point", value),
         }
+    }
+}
+
+impl<C: CurveGroup> From<CurvePoint<C>> for ResultValue<C> {
+    fn from(value: CurvePoint<C>) -> Self {
+        ResultValue::Point(value)
     }
 }
 
@@ -182,12 +211,24 @@ impl<C: CurveGroup> From<ResultValue<C>> for Vec<CurvePoint<C>> {
     }
 }
 
+impl<C: CurveGroup> From<Vec<CurvePoint<C>>> for ResultValue<C> {
+    fn from(value: Vec<CurvePoint<C>>) -> Self {
+        ResultValue::PointBatch(value)
+    }
+}
+
 impl<C: CurveGroup> From<ResultValue<C>> for PointShare<C> {
     fn from(value: ResultValue<C>) -> Self {
         match value {
             ResultValue::PointShare(share) => share,
             _ => panic!("Cannot cast {:?} to point share", value),
         }
+    }
+}
+
+impl<C: CurveGroup> From<PointShare<C>> for ResultValue<C> {
+    fn from(value: PointShare<C>) -> Self {
+        ResultValue::PointShare(value)
     }
 }
 

--- a/online-phase/src/lib.rs
+++ b/online-phase/src/lib.rs
@@ -57,7 +57,7 @@ pub mod test_helpers {
         algebra::{AuthenticatedPointResult, AuthenticatedScalarResult, CurvePoint, Scalar},
         fabric::ExecutorSizeHints,
         network::{MockNetwork, NoRecvNetwork, UnboundedDuplexStream},
-        offline_prep::{OfflinePhase, PartyIDBeaverSource},
+        offline_prep::{PartyIDBeaverSource, PreprocessingPhase},
         MpcFabric, PARTY0, PARTY1,
     };
 
@@ -149,7 +149,7 @@ pub mod test_helpers {
         party1_beaver: B,
     ) -> (T, T)
     where
-        B: 'static + OfflinePhase<TestCurve>,
+        B: 'static + PreprocessingPhase<TestCurve>,
         T: Send + 'static,
         S: Future<Output = T> + Send + 'static,
         F: FnMut(MpcFabric<TestCurve>) -> S,

--- a/online-phase/src/offline_prep.rs
+++ b/online-phase/src/offline_prep.rs
@@ -6,12 +6,36 @@ use itertools::Itertools;
 
 use crate::algebra::{Scalar, ScalarShare};
 
-/// OfflinePhase implements both the functionality for:
-///     1. Single additively shared values [x] where party 1 holds x_1 and party
-///        2 holds x_2 such that x_1 + x_2 = x
-///     2. Beaver triplets; additively shared values [a], [b], [c] such that a *
-///        b = c
-pub trait OfflinePhase<C: CurveGroup>: Send + Sync {
+/// PreprocessingPhase implements both the functionality for:
+///     1. Input authentication and sharing
+///     2. Shared values from the pre-processing phase
+pub trait PreprocessingPhase<C: CurveGroup>: Send + Sync {
+    // === Input Authentication === //
+    /// Get the local party's share of the mac key
+    fn get_mac_key_share(&self) -> Scalar<C>;
+    /// Get an input mask value for the local party
+    ///
+    /// That is, a cleartext random value and the local party's share of the
+    /// value
+    fn next_local_input_mask(&mut self) -> (Scalar<C>, ScalarShare<C>);
+    /// Get a batch of input mask values for the local party
+    fn next_local_input_mask_batch(
+        &mut self,
+        num_values: usize,
+    ) -> (Vec<Scalar<C>>, Vec<ScalarShare<C>>) {
+        (0..num_values).map(|_| self.next_local_input_mask()).unzip()
+    }
+    /// Get an input mask share for the counterparty
+    ///
+    /// That is, a share of a random value for which the counterparty holds the
+    /// cleartext
+    fn next_counterparty_input_mask(&mut self) -> ScalarShare<C>;
+    /// Get a batch of input mask shares for the counterparty
+    fn next_counterparty_input_mask_batch(&mut self, num_values: usize) -> Vec<ScalarShare<C>> {
+        (0..num_values).map(|_| self.next_counterparty_input_mask()).collect_vec()
+    }
+
+    // === Shared Values === //
     /// Fetch the next shared single bit
     fn next_shared_bit(&mut self) -> ScalarShare<C>;
     /// Fetch the next shared batch of bits
@@ -70,6 +94,7 @@ pub struct PartyIDBeaverSource {
 impl PartyIDBeaverSource {
     /// Create a new beaver source given the local party_id
     pub fn new(party_id: u64) -> Self {
+        assert!(party_id == 0 || party_id == 1);
         Self { party_id }
     }
 }
@@ -81,10 +106,30 @@ impl PartyIDBeaverSource {
 /// We also assume the MAC key is a secret sharing of 1 with each party holding
 /// their own party id as a mac key share
 #[cfg(any(feature = "test_helpers", test))]
-impl<C: CurveGroup> OfflinePhase<C> for PartyIDBeaverSource {
+impl<C: CurveGroup> PreprocessingPhase<C> for PartyIDBeaverSource {
+    fn get_mac_key_share(&self) -> Scalar<C> {
+        Scalar::from(self.party_id)
+    }
+
+    fn next_local_input_mask(&mut self) -> (Scalar<C>, ScalarShare<C>) {
+        let party = Scalar::from(self.party_id);
+        let value = Scalar::from(3u8);
+        let share = party * value;
+        let mac = party * value;
+
+        (value, ScalarShare::new(share, mac))
+    }
+
+    fn next_counterparty_input_mask(&mut self) -> ScalarShare<C> {
+        let party = Scalar::from(self.party_id);
+        let value = Scalar::from(3u8) * party;
+        let mac = party * value;
+
+        ScalarShare::new(value, mac)
+    }
+
     fn next_shared_bit(&mut self) -> ScalarShare<C> {
         // Simply output partyID, assume partyID \in {0, 1}
-        assert!(self.party_id == 0 || self.party_id == 1);
         let value = Scalar::from(self.party_id);
         ScalarShare::new(value, value)
     }
@@ -94,10 +139,10 @@ impl<C: CurveGroup> OfflinePhase<C> for PartyIDBeaverSource {
         let b = Scalar::from(3u8);
         let c = Scalar::from(6u8);
 
-        let party_id = Scalar::from(self.party_id);
-        let a_mac = party_id * a;
-        let b_mac = party_id * b;
-        let c_mac = party_id * c;
+        let key = self.get_mac_key_share();
+        let a_mac = key * a;
+        let b_mac = key * b;
+        let c_mac = key * c;
 
         let (a_share, b_share, c_share) = if self.party_id == 0 {
             (Scalar::from(1u64), Scalar::from(3u64), Scalar::from(2u64))


### PR DESCRIPTION
### Purpose
This PR uses the input masks generated in the offline phase to authenticate inputs in the online phase. This allows for inputs to be authenticated in a single round without using FHE primitives at runtime.

### Testing
- All unit tests pass