### PR TITLE
offline-phase: lowgear: Implement input auth methods for lowgear

### DIFF
--- a/offline-phase/src/lib.rs
+++ b/offline-phase/src/lib.rs
@@ -189,9 +189,10 @@ pub(crate) mod test_helpers {
         let mut lowgear2 = LowGear::new(net2);
 
         // Setup the lowgear instances
-        let params = &lowgear1.params;
-        let keypair1 = BGVKeypair::gen(params);
-        let keypair2 = BGVKeypair::gen(params);
+        let params1 = &lowgear1.params;
+        let params2 = &lowgear2.params;
+        let keypair1 = BGVKeypair::gen(params1);
+        let keypair2 = BGVKeypair::gen(params2);
 
         let mac_share1 = Scalar::random(&mut rng);
         let mac_share2 = Scalar::random(&mut rng);
@@ -204,9 +205,9 @@ pub(crate) mod test_helpers {
 
         // Set the exchanged values
         lowgear1.other_pk = Some(keypair2.public_key());
-        lowgear1.other_mac_enc = Some(encrypt_all(mac_share2, &keypair2.public_key(), params));
+        lowgear1.other_mac_enc = Some(encrypt_all(mac_share2, &keypair2.public_key(), params1));
         lowgear2.other_pk = Some(keypair1.public_key());
-        lowgear2.other_mac_enc = Some(encrypt_all(mac_share1, &keypair1.public_key(), params));
+        lowgear2.other_mac_enc = Some(encrypt_all(mac_share1, &keypair1.public_key(), params2));
 
         (lowgear1, lowgear2)
     }

--- a/offline-phase/src/lowgear/mod.rs
+++ b/offline-phase/src/lowgear/mod.rs
@@ -115,6 +115,7 @@ impl<C: CurveGroup, N: MpcNetwork<C> + Unpin> LowGear<C, N> {
             self.inverse_tuples.clone(),
             self.shared_bits.clone(),
             self.shared_randomness.clone(),
+            self.input_masks.clone(),
             self.triples.clone(),
         ))
     }


### PR DESCRIPTION
### Purpose
This PR implements the input authentication methods for the `LowGearPrep` type, completing its implementation as a preprocessing phase. 

### Testing
- Unit tests pass
- Tested an MPC circuit run an a `LowGearPrep` offline phase