### PR TITLE
mp-spdz-rs: fhe: plaintext: Use `rayon` iter in plaintext vec ops

### DIFF
--- a/mp-spdz-rs/Cargo.toml
+++ b/mp-spdz-rs/Cargo.toml
@@ -4,10 +4,16 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
+parallel = ["ark-ec/parallel", "ark-ff/parallel", "dep:rayon"]
 test-helpers = ["dep:rand"]
 
 [[bench]]
 name = "plaintext_ops"
+harness = false
+required-features = ["test-helpers"]
+
+[[bench]]
+name = "plaintext_vec_ops"
 harness = false
 required-features = ["test-helpers"]
 
@@ -19,8 +25,8 @@ required-features = ["test-helpers"]
 [dependencies]
 # === Arithmetic + Crypto === #
 ark-bn254 = "0.4"
-ark-ec = { version = "0.4", features = ["parallel"] }
-ark-ff = { version = "0.4", features = ["parallel"] }
+ark-ec = { version = "0.4" }
+ark-ff = { version = "0.4" }
 ark-mpc = { path = "../online-phase" }
 
 # === Bindings === #
@@ -28,6 +34,7 @@ cxx = "1.0"
 
 # === Misc === #
 rand = { version = "0.8.4", optional = true }
+rayon = { version = "1.10", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]

--- a/mp-spdz-rs/benches/plaintext_vec_ops.rs
+++ b/mp-spdz-rs/benches/plaintext_vec_ops.rs
@@ -1,0 +1,71 @@
+//! Benchmarks for arithmetic on plaintext vectors
+
+use std::time::{Duration, Instant};
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use mp_spdz_rs::benchmark_helpers::random_plaintext_vec;
+use mp_spdz_rs::fhe::params::BGVParams;
+use mp_spdz_rs::TestCurve;
+
+/// Benchmark plaintext vector addition
+fn benchmark_plaintext_vec_addition(c: &mut Criterion) {
+    let mut group = c.benchmark_group("plaintext-vector-ops");
+
+    let params = BGVParams::<TestCurve>::new_no_mults();
+    let slots = params.plaintext_slots();
+
+    for vec_length in [10usize, 100, 1000] {
+        group.throughput(criterion::Throughput::Elements((slots * vec_length) as u64));
+        group.bench_function(BenchmarkId::new("add", vec_length), |b| {
+            b.iter_custom(|n_iters| {
+                let mut total_time = Duration::default();
+
+                for _ in 0..n_iters {
+                    let plaintext1 = random_plaintext_vec(vec_length, &params);
+                    let plaintext2 = random_plaintext_vec(vec_length, &params);
+
+                    let start = Instant::now();
+                    let _ = black_box(&plaintext1 + &plaintext2);
+                    total_time += start.elapsed();
+                }
+
+                total_time
+            })
+        });
+    }
+}
+
+/// Benchmark plaintext vector multiplication
+fn benchmark_plaintext_vec_multiplication(c: &mut Criterion) {
+    let mut group = c.benchmark_group("plaintext-vector-ops");
+
+    let params = BGVParams::<TestCurve>::new_no_mults();
+    let slots = params.plaintext_slots();
+
+    for vec_length in [10usize, 100, 1000] {
+        group.throughput(criterion::Throughput::Elements((slots * vec_length) as u64));
+        group.bench_function(BenchmarkId::new("mul", vec_length), |b| {
+            b.iter_custom(|n_iters| {
+                let mut total_time = Duration::default();
+
+                for _ in 0..n_iters {
+                    let plaintext1 = random_plaintext_vec(vec_length, &params);
+                    let plaintext2 = random_plaintext_vec(vec_length, &params);
+
+                    let start = Instant::now();
+                    let _ = black_box(&plaintext1 * &plaintext2);
+                    total_time += start.elapsed();
+                }
+
+                total_time
+            })
+        });
+    }
+}
+
+criterion_group! {
+    name = plaintext_vec_ops;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark_plaintext_vec_addition, benchmark_plaintext_vec_multiplication
+}
+criterion_main!(plaintext_vec_ops);

--- a/mp-spdz-rs/src/lib.rs
+++ b/mp-spdz-rs/src/lib.rs
@@ -51,7 +51,10 @@ pub mod benchmark_helpers {
     use ark_mpc::algebra::Scalar;
     use rand::thread_rng;
 
-    use crate::fhe::{params::BGVParams, plaintext::Plaintext};
+    use crate::fhe::{
+        params::BGVParams,
+        plaintext::{Plaintext, PlaintextVector},
+    };
 
     /// Get a random plaintext filled with random values
     pub fn random_plaintext<C: CurveGroup>(params: &BGVParams<C>) -> Plaintext<C> {
@@ -63,5 +66,18 @@ pub mod benchmark_helpers {
         }
 
         pt
+    }
+
+    /// Get a random vector of plaintexts
+    pub fn random_plaintext_vec<C: CurveGroup>(
+        n: usize,
+        params: &BGVParams<C>,
+    ) -> PlaintextVector<C> {
+        let mut vec = PlaintextVector::empty();
+        for _ in 0..n {
+            vec.push(&random_plaintext(params));
+        }
+
+        vec
     }
 }


### PR DESCRIPTION
### Purpose
This PR updates the plaintext vector operations to use `rayon` iterators when the `parallel` feature flag is enabled.

This PR also adds `plaintext_vec_ops` benchmarks to the `mp-spdz-rs` crate to measure this improvement.

### Testing
- Unit tests pass
- Benchmarks run and show improvement with `parallel` enabled