### PR TITLE
integration: lowgear: Add lowgear integration test

### DIFF
--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -6,7 +6,9 @@ edition = "2021"
 [dependencies]
 # === Cryptography === #
 ark-bn254 = "0.4"
+ark-ec = "0.4"
 ark-mpc = { path = "../online-phase", features = ["test_helpers"] }
+ark-mpc-offline = { path = "../offline-phase", features = ["parallel"] }
 
 # === Runtime + Harness === #
 clap = { version = "3.2.8", features = ["derive"] }

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -5,6 +5,17 @@ WORKDIR /build
 COPY ./rust-toolchain ./rust-toolchain
 RUN rustup install $(cat rust-toolchain)
 
+RUN apt-get update && apt-get install -y \
+    libsodium-dev \
+    libgmp-dev \
+    libboost-all-dev \
+    libntl-dev \
+    libssl-dev \
+    clang 
+
+ENV PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
+ENV CXX=clang++
+
 # Install chef and generate a recipe
 RUN cargo install cargo-chef
 

--- a/integration/src/helpers.rs
+++ b/integration/src/helpers.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use ark_mpc::{
     algebra::{AuthenticatedPointResult, AuthenticatedScalarResult},
     network::{NetworkPayload, PartyId},
-    {MpcFabric, ResultHandle, ResultValue},
+    MpcFabric, ResultHandle, ResultValue,
 };
 use futures::{future::join_all, Future};
 use itertools::Itertools;

--- a/integration/src/lowgear.rs
+++ b/integration/src/lowgear.rs
@@ -1,0 +1,20 @@
+//! Integration tests for the lowgear offline phase
+
+use ark_mpc_offline::lowgear::LowGear;
+use futures::executor::block_on;
+
+use crate::{
+    helpers::{await_result, await_result_with_error},
+    IntegrationTest, IntegrationTestArgs,
+};
+
+/// A basic smoke test that
+fn test_keygen(test_args: &IntegrationTestArgs) -> Result<(), String> {
+    println!("got here");
+    let net = await_result(test_args.new_quic_conn());
+    let mut lowgear = LowGear::new(net);
+
+    await_result_with_error(lowgear.run_key_exchange())
+}
+
+inventory::submit!(IntegrationTest { name: "lowgear::test_keygen", test_fn: test_keygen });

--- a/mp-spdz-rs/build.rs
+++ b/mp-spdz-rs/build.rs
@@ -144,10 +144,11 @@ fn find_package_linux(name: &str) -> String {
     match conf {
         Ok(lib) => lib.include_paths[0].to_str().unwrap().to_string(),
         Err(e) => {
-            panic!(
+            println!(
                 "Package not found: {}\nTry running:\n\t `{{apt-get, yum}} install {}`\n",
                 e, name
-            )
+            );
+            "/usr/include".to_string()
         },
     }
 }

--- a/offline-phase/src/lowgear/commit_reveal.rs
+++ b/offline-phase/src/lowgear/commit_reveal.rs
@@ -26,8 +26,7 @@ impl<C: CurveGroup, N: MpcNetwork<C> + Unpin + Send> LowGear<C, N> {
         values: &[Scalar<C>],
     ) -> Result<Vec<Scalar<C>>, LowGearError> {
         // Send the values
-        self.send_network_payload(values.to_vec()).await?;
-        let their_values: Vec<Scalar<C>> = self.receive_network_payload().await?;
+        let their_values = self.exchange_network_payload(values.to_vec()).await?;
         let res = their_values.iter().zip(values.iter()).map(|(a, b)| a + b).collect();
 
         Ok(res)
@@ -50,12 +49,10 @@ impl<C: CurveGroup, N: MpcNetwork<C> + Unpin + Send> LowGear<C, N> {
     ) -> Result<Vec<Scalar<C>>, LowGearError> {
         // Hash the values
         let my_comm = Self::commit_scalars(values);
-        self.send_network_payload(my_comm).await?;
-        let their_comm: Scalar<C> = self.receive_network_payload().await?;
+        let their_comm = self.exchange_network_payload(my_comm).await?;
 
         // Reveal the values
-        self.send_network_payload(values.to_vec()).await?;
-        let their_values: Vec<Scalar<C>> = self.receive_network_payload().await?;
+        let their_values = self.exchange_network_payload(values.to_vec()).await?;
 
         // Check the counterparty's commitment
         let expected_comm = Self::commit_scalars(&their_values);

--- a/offline-phase/src/lowgear/shared_random.rs
+++ b/offline-phase/src/lowgear/shared_random.rs
@@ -71,8 +71,6 @@ impl<C: CurveGroup, N: MpcNetwork<C> + Unpin + Send> LowGear<C, N> {
 mod tests {
     use crate::test_helpers::{mock_lowgear, mock_lowgear_with_keys};
 
-    use super::*;
-
     /// Tests creating a shared vector of public randomness values
     #[tokio::test]
     async fn test_get_shared_randomness_vec() {
@@ -83,9 +81,7 @@ mod tests {
             assert_eq!(shares.len(), n);
 
             // Send the shares to one another to verify they are the same
-            lowgear.send_network_payload(shares.clone()).await.unwrap();
-            let their_shares: Vec<Scalar<_>> = lowgear.receive_network_payload().await.unwrap();
-
+            let their_shares = lowgear.exchange_network_payload(shares.clone()).await.unwrap();
             assert_eq!(shares, their_shares);
         })
         .await;


### PR DESCRIPTION
### Purpose
This PR adds an initial integration test for the lowgear offline phase. This involves fixing a few bugs:
- Getting `mp-spdz-rs` building on ubuntu
- Fixing message exchange on an async quic stream

### Todo
- Test full offline phase

### Testing
- Integration tests pass